### PR TITLE
Upgrade Gateway API to v1.4.1

### DIFF
--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -26,7 +26,7 @@ import (
 // testGatewayAPIVersion must match the major.minor version of the
 // sigs.k8s.io/gateway-api dependency in go.mod. This is updated
 // automatically by the upgrade-gateway-api workflow.
-var testGatewayAPIVersion = semver.MustParse("1.4.0")
+var testGatewayAPIVersion = semver.MustParse("1.4.1")
 
 var (
 	testEnv    *envtest.Environment


### PR DESCRIPTION
Automated Gateway API upgrade to `v1.4.1`.

Release: https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.4.1

Generated by: https://github.com/matheuscscp/cloudflare-gateway-controller/actions/runs/22037748585