### PR TITLE
Upgrade Gateway API to v1.4.1

### DIFF
--- a/charts/cloudflare-gateway-controller/templates/experimental-api.yaml
+++ b/charts/cloudflare-gateway-controller/templates/experimental-api.yaml
@@ -1,5 +1,6 @@
-{{- /* Copyright 2026 Matheus Pimenta. */ -}}
-{{- /* SPDX-License-Identifier: AGPL-3.0 */ -}}
+# Copyright 2026 Matheus Pimenta.
+# SPDX-License-Identifier: AGPL-3.0
+
 {{- if eq .Values.api.channel "experimental" }}
 # Copyright 2025 The Kubernetes Authors.
 #

--- a/charts/cloudflare-gateway-controller/templates/standard-api.yaml
+++ b/charts/cloudflare-gateway-controller/templates/standard-api.yaml
@@ -1,5 +1,6 @@
-{{- /* Copyright 2026 Matheus Pimenta. */ -}}
-{{- /* SPDX-License-Identifier: AGPL-3.0 */ -}}
+# Copyright 2026 Matheus Pimenta.
+# SPDX-License-Identifier: AGPL-3.0
+
 {{- if eq .Values.api.channel "standard" }}
 # Copyright 2025 The Kubernetes Authors.
 #


### PR DESCRIPTION
Automated Gateway API upgrade to `v1.4.1`.

Release: https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.4.1

Generated by: https://github.com/matheuscscp/cloudflare-gateway-controller/actions/runs/22205918885