### PR TITLE
Deterministic Cloudflare resource naming

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,6 +10,10 @@ on:
     - cron: "0 4 * * *" # nightly at 4 AM UTC
   workflow_dispatch:
 
+concurrency:
+  group: e2e # lock for shared Cloudflare resources
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/api/v1/cloudflaregatewaystatus_types.go
+++ b/api/v1/cloudflaregatewaystatus_types.go
@@ -64,6 +64,10 @@ type TunnelStatus struct {
 	// +optional
 	AZName string `json:"azName,omitempty"`
 
+	// ServiceNamespace is the backend service namespace (empty if not per-service).
+	// +optional
+	ServiceNamespace string `json:"serviceNamespace,omitempty"`
+
 	// ServiceName is the backend service name (empty if not per-service).
 	// +optional
 	ServiceName string `json:"serviceName,omitempty"`

--- a/api/v1/meta_types.go
+++ b/api/v1/meta_types.go
@@ -4,11 +4,50 @@
 package v1
 
 import (
+	"crypto/sha256"
 	"fmt"
+	"strings"
 	"time"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
+
+var cfClusterName string
+
+// SetClusterName sets the cluster name for deterministic resource naming.
+// Must be called before any naming functions are used.
+func SetClusterName(name string) { cfClusterName = name }
+
+// ClusterName returns the configured cluster name.
+func ClusterName() string { return cfClusterName }
+
+// ResourceName returns a deterministic resource name by hashing the
+// fully-qualified ownership fields with SHA256. The result is "gw-" +
+// the full 64 hex-char SHA256 digest (67 chars total).
+func ResourceName(parts ...string) string {
+	h := sha256.New()
+	for i, p := range parts {
+		if i > 0 {
+			h.Write([]byte("/"))
+		}
+		h.Write([]byte(p))
+	}
+	return fmt.Sprintf("gw-%x", h.Sum(nil))
+}
+
+// ResourceDescription returns a compact ownership description for Cloudflare
+// resource metadata (Description on pools/monitors/LBs, Comment on DNS records).
+// The format is kept short to fit within the 100-char DNS comment limit on free plans.
+func ResourceDescription(gw *gatewayv1.Gateway, extra ...string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "cfgw cluster:%s ns:%s gw:%s",
+		cfClusterName, gw.Namespace, gw.Name)
+	for _, e := range extra {
+		b.WriteString(" ")
+		b.WriteString(e)
+	}
+	return b.String()
+}
 
 // CRD names.
 const (
@@ -77,26 +116,25 @@ const (
 )
 
 // TunnelName returns the deterministic Cloudflare tunnel name for a Gateway.
-// The name is globally unique because it includes the Gateway's UID.
 func TunnelName(gw *gatewayv1.Gateway) string {
-	return "gateway-" + string(gw.UID)
+	return ResourceName(cfClusterName, gw.Namespace, gw.Name)
 }
 
 // TunnelNameForAZ returns the Cloudflare tunnel name for a Gateway in a specific AZ.
 func TunnelNameForAZ(gw *gatewayv1.Gateway, azName string) string {
-	return fmt.Sprintf("gateway-%s-%s", gw.UID, azName)
+	return ResourceName(cfClusterName, gw.Namespace, gw.Name, azName)
 }
 
 // TunnelNameForService returns the Cloudflare tunnel name for a Gateway
 // dedicated to a specific Service (traffic splitting mode, no AZs).
-func TunnelNameForService(gw *gatewayv1.Gateway, serviceName string) string {
-	return fmt.Sprintf("gateway-%s-%s", gw.UID, serviceName)
+func TunnelNameForService(gw *gatewayv1.Gateway, svcNamespace, svcName string) string {
+	return ResourceName(cfClusterName, gw.Namespace, gw.Name, svcNamespace, svcName)
 }
 
 // TunnelNameForServiceAZ returns the Cloudflare tunnel name for a Gateway
 // dedicated to a specific Service in a specific AZ (traffic splitting + AZs).
-func TunnelNameForServiceAZ(gw *gatewayv1.Gateway, serviceName, azName string) string {
-	return fmt.Sprintf("gateway-%s-%s-%s", gw.UID, serviceName, azName)
+func TunnelNameForServiceAZ(gw *gatewayv1.Gateway, svcNamespace, svcName, azName string) string {
+	return ResourceName(cfClusterName, gw.Namespace, gw.Name, svcNamespace, svcName, azName)
 }
 
 // CloudflaredDeploymentName returns the name of the cloudflared Deployment for a Gateway.
@@ -147,19 +185,19 @@ func TunnelTokenSecretNameForServiceAZ(gw *gatewayv1.Gateway, serviceName, azNam
 
 // MonitorName returns the Cloudflare LB monitor name for a Gateway.
 func MonitorName(gw *gatewayv1.Gateway) string {
-	return "gateway-" + string(gw.UID)
+	return ResourceName(cfClusterName, gw.Namespace, gw.Name, "monitor")
 }
 
 // PoolNameForAZ returns the Cloudflare LB pool name for a Gateway AZ
 // (geographic steering mode).
 func PoolNameForAZ(gw *gatewayv1.Gateway, azName string) string {
-	return fmt.Sprintf("gateway-%s-%s", gw.UID, azName)
+	return ResourceName(cfClusterName, gw.Namespace, gw.Name, azName)
 }
 
 // PoolNameForService returns the Cloudflare LB pool name for a Gateway Service
 // (traffic splitting mode).
-func PoolNameForService(gw *gatewayv1.Gateway, serviceName string) string {
-	return fmt.Sprintf("gateway-%s-%s", gw.UID, serviceName)
+func PoolNameForService(gw *gatewayv1.Gateway, svcNamespace, svcName string) string {
+	return ResourceName(cfClusterName, gw.Namespace, gw.Name, svcNamespace, svcName)
 }
 
 // ReconcileInterval returns the reconciliation interval for an object

--- a/api/v1/meta_types_test.go
+++ b/api/v1/meta_types_test.go
@@ -9,141 +9,167 @@ import (
 
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	apiv1 "github.com/matheuscscp/cloudflare-gateway-controller/api/v1"
 )
 
-func TestTunnelName(t *testing.T) {
-	g := NewWithT(t)
-	gw := &gatewayv1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{UID: types.UID("abc-123")},
-	}
-	g.Expect(apiv1.TunnelName(gw)).To(Equal("gateway-abc-123"))
+func init() {
+	apiv1.SetClusterName("test-cluster")
 }
 
-func TestCloudflaredDeploymentName(t *testing.T) {
-	g := NewWithT(t)
-	gw := &gatewayv1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{Name: "my-gw"},
-	}
-	g.Expect(apiv1.CloudflaredDeploymentName(gw)).To(Equal("cloudflared-my-gw"))
-}
-
-func TestTunnelTokenSecretName(t *testing.T) {
-	g := NewWithT(t)
-	gw := &gatewayv1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{Name: "my-gw"},
-	}
-	g.Expect(apiv1.TunnelTokenSecretName(gw)).To(Equal("cloudflared-token-my-gw"))
-}
-
-func TestFinalizerGatewayClass(t *testing.T) {
-	g := NewWithT(t)
-	gw := &gatewayv1.Gateway{
+func testGateway() *gatewayv1.Gateway {
+	return &gatewayv1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-gw",
 			Namespace: "my-ns",
 		},
 	}
-	g.Expect(apiv1.FinalizerGatewayClass(gw)).To(Equal("gateway-exists-finalizer.gateway.networking.k8s.io/my-gw.my-ns"))
+}
+
+func TestResourceName(t *testing.T) {
+	g := NewWithT(t)
+	name := apiv1.ResourceName("a", "b", "c")
+	g.Expect(name).To(HavePrefix("gw-"))
+	// Full SHA256 = 64 hex chars, "gw-" prefix = 67 chars total.
+	g.Expect(name).To(HaveLen(67))
+	// Same inputs produce same output.
+	g.Expect(apiv1.ResourceName("a", "b", "c")).To(Equal(name))
+	// Different inputs produce different output.
+	g.Expect(apiv1.ResourceName("a", "b", "d")).NotTo(Equal(name))
+}
+
+func TestResourceDescription(t *testing.T) {
+	g := NewWithT(t)
+	gw := testGateway()
+	desc := apiv1.ResourceDescription(gw)
+	g.Expect(desc).To(Equal("cfgw cluster:test-cluster ns:my-ns gw:my-gw"))
+	descWithExtra := apiv1.ResourceDescription(gw, "az:us-east-1a", "svc:default/web")
+	g.Expect(descWithExtra).To(Equal("cfgw cluster:test-cluster ns:my-ns gw:my-gw az:us-east-1a svc:default/web"))
+}
+
+func TestTunnelName(t *testing.T) {
+	g := NewWithT(t)
+	gw := testGateway()
+	name := apiv1.TunnelName(gw)
+	g.Expect(name).To(HavePrefix("gw-"))
+	g.Expect(name).To(HaveLen(67))
+	// Deterministic: same cluster/ns/gw always produces the same name.
+	g.Expect(apiv1.TunnelName(gw)).To(Equal(name))
 }
 
 func TestTunnelNameForAZ(t *testing.T) {
 	g := NewWithT(t)
-	gw := &gatewayv1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{UID: types.UID("abc-123")},
-	}
-	g.Expect(apiv1.TunnelNameForAZ(gw, "us-east-1a")).To(Equal("gateway-abc-123-us-east-1a"))
+	gw := testGateway()
+	name := apiv1.TunnelNameForAZ(gw, "us-east-1a")
+	g.Expect(name).To(HavePrefix("gw-"))
+	g.Expect(name).To(HaveLen(67))
+	// Different AZ produces different name.
+	g.Expect(apiv1.TunnelNameForAZ(gw, "us-west-2b")).NotTo(Equal(name))
 }
 
 func TestTunnelNameForService(t *testing.T) {
 	g := NewWithT(t)
-	gw := &gatewayv1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{UID: types.UID("abc-123")},
-	}
-	g.Expect(apiv1.TunnelNameForService(gw, "web")).To(Equal("gateway-abc-123-web"))
+	gw := testGateway()
+	name := apiv1.TunnelNameForService(gw, "default", "web")
+	g.Expect(name).To(HavePrefix("gw-"))
+	g.Expect(name).To(HaveLen(67))
+	// Different service namespace produces different name.
+	g.Expect(apiv1.TunnelNameForService(gw, "other-ns", "web")).NotTo(Equal(name))
+	// Different service name produces different name.
+	g.Expect(apiv1.TunnelNameForService(gw, "default", "api")).NotTo(Equal(name))
 }
 
 func TestTunnelNameForServiceAZ(t *testing.T) {
 	g := NewWithT(t)
-	gw := &gatewayv1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{UID: types.UID("abc-123")},
-	}
-	g.Expect(apiv1.TunnelNameForServiceAZ(gw, "web", "us-east-1a")).To(Equal("gateway-abc-123-web-us-east-1a"))
+	gw := testGateway()
+	name := apiv1.TunnelNameForServiceAZ(gw, "default", "web", "us-east-1a")
+	g.Expect(name).To(HavePrefix("gw-"))
+	g.Expect(name).To(HaveLen(67))
+	// Different AZ produces different name.
+	g.Expect(apiv1.TunnelNameForServiceAZ(gw, "default", "web", "us-west-2b")).NotTo(Equal(name))
+}
+
+func TestCloudflaredDeploymentName(t *testing.T) {
+	g := NewWithT(t)
+	gw := testGateway()
+	g.Expect(apiv1.CloudflaredDeploymentName(gw)).To(Equal("cloudflared-my-gw"))
+}
+
+func TestTunnelTokenSecretName(t *testing.T) {
+	g := NewWithT(t)
+	gw := testGateway()
+	g.Expect(apiv1.TunnelTokenSecretName(gw)).To(Equal("cloudflared-token-my-gw"))
+}
+
+func TestFinalizerGatewayClass(t *testing.T) {
+	g := NewWithT(t)
+	gw := testGateway()
+	g.Expect(apiv1.FinalizerGatewayClass(gw)).To(Equal("gateway-exists-finalizer.gateway.networking.k8s.io/my-gw.my-ns"))
 }
 
 func TestCloudflaredDeploymentNameForAZ(t *testing.T) {
 	g := NewWithT(t)
-	gw := &gatewayv1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{Name: "my-gw"},
-	}
+	gw := testGateway()
 	g.Expect(apiv1.CloudflaredDeploymentNameForAZ(gw, "us-east-1a")).To(Equal("cloudflared-my-gw-us-east-1a"))
 }
 
 func TestCloudflaredDeploymentNameForService(t *testing.T) {
 	g := NewWithT(t)
-	gw := &gatewayv1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{Name: "my-gw"},
-	}
+	gw := testGateway()
 	g.Expect(apiv1.CloudflaredDeploymentNameForService(gw, "web")).To(Equal("cloudflared-my-gw-web"))
 }
 
 func TestCloudflaredDeploymentNameForServiceAZ(t *testing.T) {
 	g := NewWithT(t)
-	gw := &gatewayv1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{Name: "my-gw"},
-	}
+	gw := testGateway()
 	g.Expect(apiv1.CloudflaredDeploymentNameForServiceAZ(gw, "web", "us-east-1a")).To(Equal("cloudflared-my-gw-web-us-east-1a"))
 }
 
 func TestTunnelTokenSecretNameForAZ(t *testing.T) {
 	g := NewWithT(t)
-	gw := &gatewayv1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{Name: "my-gw"},
-	}
+	gw := testGateway()
 	g.Expect(apiv1.TunnelTokenSecretNameForAZ(gw, "us-east-1a")).To(Equal("cloudflared-token-my-gw-us-east-1a"))
 }
 
 func TestTunnelTokenSecretNameForService(t *testing.T) {
 	g := NewWithT(t)
-	gw := &gatewayv1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{Name: "my-gw"},
-	}
+	gw := testGateway()
 	g.Expect(apiv1.TunnelTokenSecretNameForService(gw, "web")).To(Equal("cloudflared-token-my-gw-web"))
 }
 
 func TestTunnelTokenSecretNameForServiceAZ(t *testing.T) {
 	g := NewWithT(t)
-	gw := &gatewayv1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{Name: "my-gw"},
-	}
+	gw := testGateway()
 	g.Expect(apiv1.TunnelTokenSecretNameForServiceAZ(gw, "web", "us-east-1a")).To(Equal("cloudflared-token-my-gw-web-us-east-1a"))
 }
 
 func TestMonitorName(t *testing.T) {
 	g := NewWithT(t)
-	gw := &gatewayv1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{UID: types.UID("abc-123")},
-	}
-	g.Expect(apiv1.MonitorName(gw)).To(Equal("gateway-abc-123"))
+	gw := testGateway()
+	name := apiv1.MonitorName(gw)
+	g.Expect(name).To(HavePrefix("gw-"))
+	g.Expect(name).To(HaveLen(67))
 }
 
 func TestPoolNameForAZ(t *testing.T) {
 	g := NewWithT(t)
-	gw := &gatewayv1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{UID: types.UID("abc-123")},
-	}
-	g.Expect(apiv1.PoolNameForAZ(gw, "us-east-1a")).To(Equal("gateway-abc-123-us-east-1a"))
+	gw := testGateway()
+	name := apiv1.PoolNameForAZ(gw, "us-east-1a")
+	g.Expect(name).To(HavePrefix("gw-"))
+	g.Expect(name).To(HaveLen(67))
+	// Different AZ produces different name.
+	g.Expect(apiv1.PoolNameForAZ(gw, "us-west-2b")).NotTo(Equal(name))
 }
 
 func TestPoolNameForService(t *testing.T) {
 	g := NewWithT(t)
-	gw := &gatewayv1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{UID: types.UID("abc-123")},
-	}
-	g.Expect(apiv1.PoolNameForService(gw, "web")).To(Equal("gateway-abc-123-web"))
+	gw := testGateway()
+	name := apiv1.PoolNameForService(gw, "default", "web")
+	g.Expect(name).To(HavePrefix("gw-"))
+	g.Expect(name).To(HaveLen(67))
+	// Different service namespace produces different name.
+	g.Expect(apiv1.PoolNameForService(gw, "other-ns", "web")).NotTo(Equal(name))
 }
 
 func TestReconcileInterval(t *testing.T) {

--- a/charts/cloudflare-gateway-controller/templates/crds.yaml
+++ b/charts/cloudflare-gateway-controller/templates/crds.yaml
@@ -1367,6 +1367,10 @@ spec:
                       description: ServiceName is the backend service name (empty
                         if not per-service).
                       type: string
+                    serviceNamespace:
+                      description: ServiceNamespace is the backend service namespace
+                        (empty if not per-service).
+                      type: string
                   required:
                   - deploymentName
                   - id

--- a/charts/cloudflare-gateway-controller/templates/deployment.yaml
+++ b/charts/cloudflare-gateway-controller/templates/deployment.yaml
@@ -36,6 +36,7 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         args:
+        - --cluster-name={{ required "config.clusterName is required" .Values.config.clusterName }}
         {{- if .Values.config.cloudflaredImage }}
         - --cloudflared-image={{ .Values.config.cloudflaredImage }}
         {{- end }}

--- a/charts/cloudflare-gateway-controller/values.yaml
+++ b/charts/cloudflare-gateway-controller/values.yaml
@@ -15,6 +15,7 @@ image:
 replicas: 1
 
 config:
+  clusterName: "" # Required. Unique cluster identifier for deterministic Cloudflare resource naming.
   cloudflaredImage: "" # Defaults to the built-in DefaultCloudflaredImage.
 
 resources:

--- a/cmd/cfgwctl/dns.go
+++ b/cmd/cfgwctl/dns.go
@@ -61,7 +61,7 @@ func newDNSFindZoneCmd(credentialsFile *string) *cobra.Command {
 }
 
 func newDNSEnsureCNAMECmd(credentialsFile *string) *cobra.Command {
-	var zoneID, hostname, target string
+	var zoneID, hostname, target, comment string
 	cmd := &cobra.Command{
 		Use:   "ensure-cname",
 		Short: "Ensure a DNS CNAME record exists",
@@ -70,12 +70,13 @@ func newDNSEnsureCNAMECmd(credentialsFile *string) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return c.EnsureDNSCNAME(cmd.Context(), zoneID, hostname, target)
+			return c.EnsureDNSCNAME(cmd.Context(), zoneID, hostname, target, comment)
 		},
 	}
 	cmd.Flags().StringVar(&zoneID, "zone-id", "", "zone ID")
 	cmd.Flags().StringVar(&hostname, "hostname", "", "CNAME hostname")
 	cmd.Flags().StringVar(&target, "target", "", "CNAME target")
+	cmd.Flags().StringVar(&comment, "comment", "", "DNS record comment")
 	cobra.CheckErr(cmd.MarkFlagRequired("zone-id"))
 	cobra.CheckErr(cmd.MarkFlagRequired("hostname"))
 	cobra.CheckErr(cmd.MarkFlagRequired("target"))

--- a/docs/dev/e2e-tests.md
+++ b/docs/dev/e2e-tests.md
@@ -40,8 +40,16 @@ minutes.
      `e2e-lib.sh`). The test output is also saved to a log file (e.g.
      `test-e2e-ha.log`). Tail both files — there is no need to run
      `kubectl logs` separately.
+   - **Never sleep more than 30 seconds** between checks. You must wake up
+     frequently so the user can interact with you. Use `sleep 30` between
+     tail checks, never longer than 30 seconds.
    - If you spot an error in the logs, you can kill the test, fix the issue,
      and re-run immediately — saving the entire retry wait.
+   - **Do NOT wrap the make command with another `tee`.** The Makefile already
+     pipes output through `tee` to a log file (e.g. `test-e2e-ha.log`). Adding
+     a second `tee` to the same file causes garbled, duplicated output that is
+     unreadable. Just launch the make command directly and tail the log file
+     separately.
 6. **Clean up orphaned Cloudflare resources before retrying** if a previous
    run failed mid-way. Leftover tunnels/LBs will cause confusing failures.
 

--- a/docs/tests/simple.md
+++ b/docs/tests/simple.md
@@ -189,3 +189,36 @@ rejects it with `Accepted=False` and reason `ListenersNotValid`.
 2. Verify `Accepted` condition is `False`.
 3. Verify `Accepted` reason is `ListenersNotValid`.
 4. Delete `Gateway`; verify deleted.
+
+## test_cluster_recreation
+
+Proves that deterministic Cloudflare resource naming enables cluster recreation
+without leaking resources. A reborn cluster with the same `clusterName` adopts
+existing Cloudflare resources (tunnel, DNS CNAME) instead of creating duplicates.
+
+**Must run last** because it destroys and recreates the kind cluster.
+
+**Resources created:**
+- `CloudflareGatewayParameters` with DNS zone config
+- `Gateway`, `Service`, and `HTTPRoute`
+
+**Cloudflare resources:** 1 tunnel, 1 DNS CNAME (adopted after recreation).
+
+**Steps:**
+
+1. Create `CloudflareGatewayParameters`, `Gateway`, `Service`, and `HTTPRoute`;
+   wait for Programmed.
+2. Record the Cloudflare tunnel ID.
+3. Verify DNS CNAME exists.
+4. Delete the kind cluster.
+5. Recreate the kind cluster with the same name.
+6. Reinstall controller, recreate namespace and GatewayClass.
+7. Recreate the same `Gateway`, `Service`, and `HTTPRoute`.
+8. Wait for Programmed.
+9. Verify tunnel ID is **unchanged** (same as before — adopted, not recreated).
+10. Verify tunnel config includes the hostname.
+11. Verify DNS CNAME still exists.
+12. Delete `HTTPRoute` and `Gateway`.
+13. Verify tunnel deleted by finalizer.
+14. Verify DNS CNAME deleted.
+15. Clean up `CloudflareGatewayParameters` and `Service`.

--- a/hack/cleanup-cloudflare.sh
+++ b/hack/cleanup-cloudflare.sh
@@ -2,9 +2,11 @@
 # Copyright 2026 Matheus Pimenta.
 # SPDX-License-Identifier: AGPL-3.0
 #
-# Cleanup script for removing leftover Cloudflare resources (load balancers,
-# pools, monitors, tunnels, and DNS CNAME records) created by the controller
-# or e2e tests.
+# Cleanup script for removing ALL Cloudflare resources in the test account:
+# load balancers, pools, monitors, tunnels, and DNS CNAME records.
+#
+# This account is dedicated to this project's e2e tests, so we clean
+# everything without worrying about naming conventions.
 #
 # Optional environment variables:
 #   CREDENTIALS_FILE   — path to credentials file (default: ./api.token)
@@ -30,8 +32,8 @@ ZONE_IDS=$(cfgwctl dns list-zones | jq -r '.zoneIds[]')
 # ─── Load Balancer cleanup ────────────────────────────────────────────────────
 # Order matters: delete LBs first (they reference pools), then pools, then monitors.
 
-echo "==> Listing all managed pools (prefix 'gateway-')..."
-POOLS=$(cfgwctl lb list-pools --prefix "gateway-")
+echo "==> Listing all pools..."
+POOLS=$(cfgwctl lb list-pools --prefix "")
 POOL_COUNT=$(echo "$POOLS" | jq 'length')
 echo "==> Found $POOL_COUNT pool(s)"
 

--- a/hack/e2e-lib.sh
+++ b/hack/e2e-lib.sh
@@ -87,6 +87,18 @@ cfgwctl() { "$CFGWCTL" --credentials-file "$CREDENTIALS_FILE" "$@"; }
 export -f cfgwctl
 export CFGWCTL CREDENTIALS_FILE
 
+# cf_resource_name computes a deterministic Cloudflare resource name from the
+# given parts, matching the Go ResourceName() function: "gw-" + hex(sha256(part1/part2/...)).
+cf_resource_name() {
+    local input=""
+    for part in "$@"; do
+        [ -n "$input" ] && input+="/"
+        input+="$part"
+    done
+    echo -n "gw-$(printf '%s' "$input" | sha256sum | cut -d' ' -f1)"
+}
+export -f cf_resource_name
+
 # ─── Prerequisites ────────────────────────────────────────────────────────────
 
 validate_prerequisites() {
@@ -181,6 +193,7 @@ install_controller() {
         --set image.repository="$IMAGE_REPO" \
         --set image.tag="$IMAGE_TAG" \
         --set image.pullPolicy=Never \
+        --set config.clusterName="$KIND_CLUSTER_NAME" \
         --set 'podArgs[0]=--log-level=debug' \
         --wait --timeout 120s
 

--- a/hack/e2e-test-ha.sh
+++ b/hack/e2e-test-ha.sh
@@ -35,8 +35,10 @@ ensure_gatewayclass
 
 # ─── Shared state across tests ───────────────────────────────────────────────
 # These are populated by test_ha_basic and used by subsequent tests.
-GW_UID=""
-TUNNEL_PREFIX=""
+GW_NAME=""
+TUNNEL_NAME_AZ_A=""
+TUNNEL_NAME_AZ_B=""
+MONITOR_NAME=""
 ZONE_ID=""
 HOSTNAME_A=""
 HOSTNAME_B=""
@@ -97,18 +99,20 @@ EOF
         || fail "ha-gw did not become Programmed"
     pass "ha-gw is Programmed"
 
-    GW_UID=$(kubectl get gateway ha-gw -n "$TEST_NS" -o jsonpath='{.metadata.uid}')
-    TUNNEL_PREFIX="gateway-${GW_UID}"
+    GW_NAME="ha-gw"
+    TUNNEL_NAME_AZ_A=$(cf_resource_name "$KIND_CLUSTER_NAME" "$TEST_NS" "$GW_NAME" "az-a")
+    TUNNEL_NAME_AZ_B=$(cf_resource_name "$KIND_CLUSTER_NAME" "$TEST_NS" "$GW_NAME" "az-b")
+    MONITOR_NAME=$(cf_resource_name "$KIND_CLUSTER_NAME" "$TEST_NS" "$GW_NAME" "monitor")
 
     # Verify 2 tunnels (one per AZ).
     local tunnel_id_a tunnel_id_b
     log "Verifying tunnel for az-a..."
-    tunnel_id_a=$(cfgwctl tunnel get-id --name "${TUNNEL_PREFIX}-az-a" | jq -r '.tunnelId')
+    tunnel_id_a=$(cfgwctl tunnel get-id --name "$TUNNEL_NAME_AZ_A" | jq -r '.tunnelId')
     [ -n "$tunnel_id_a" ] && [ "$tunnel_id_a" != "null" ] || fail "tunnel az-a not found"
     pass "Tunnel az-a exists: $tunnel_id_a"
 
     log "Verifying tunnel for az-b..."
-    tunnel_id_b=$(cfgwctl tunnel get-id --name "${TUNNEL_PREFIX}-az-b" | jq -r '.tunnelId')
+    tunnel_id_b=$(cfgwctl tunnel get-id --name "$TUNNEL_NAME_AZ_B" | jq -r '.tunnelId')
     [ -n "$tunnel_id_b" ] && [ "$tunnel_id_b" != "null" ] || fail "tunnel az-b not found"
     pass "Tunnel az-b exists: $tunnel_id_b"
 
@@ -128,30 +132,30 @@ EOF
     # Verify monitor exists.
     log "Verifying monitor exists..."
     retry 60 3 bash -c "
-        id=\$(cfgwctl lb get-monitor --name '$TUNNEL_PREFIX' | jq -r '.monitorId')
+        id=\$(cfgwctl lb get-monitor --name '$MONITOR_NAME' | jq -r '.monitorId')
         [ -n \"\$id\" ] && [ \"\$id\" != '' ]
     " || fail "monitor not found"
     local monitor_id
-    monitor_id=$(cfgwctl lb get-monitor --name "$TUNNEL_PREFIX" | jq -r '.monitorId')
+    monitor_id=$(cfgwctl lb get-monitor --name "$MONITOR_NAME" | jq -r '.monitorId')
     pass "Monitor exists: $monitor_id"
 
     # Verify 2 pools.
     log "Verifying pools exist..."
-    retry 60 3 bash -c "[ \$(cfgwctl lb list-pools --prefix '$TUNNEL_PREFIX' | jq 'length') -eq 2 ]" \
+    retry 60 3 bash -c "[ \$(cfgwctl lb list-pools --prefix 'gw-' | jq 'length') -eq 2 ]" \
         || fail "expected 2 pools"
     pass "2 pools exist"
 
     # Verify pool origins point to correct tunnels.
     log "Verifying pool az-a origin..."
     retry 60 3 bash -c "
-        origin=\$(cfgwctl lb get-pool --name '${TUNNEL_PREFIX}-az-a' | jq -r '.origins[0].address')
+        origin=\$(cfgwctl lb get-pool --name '$TUNNEL_NAME_AZ_A' | jq -r '.origins[0].address')
         [ \"\$origin\" = '${tunnel_id_a}.cfargotunnel.com' ]
     " || fail "pool az-a origin mismatch"
     pass "Pool az-a origin correct"
 
     log "Verifying pool az-b origin..."
     retry 60 3 bash -c "
-        origin=\$(cfgwctl lb get-pool --name '${TUNNEL_PREFIX}-az-b' | jq -r '.origins[0].address')
+        origin=\$(cfgwctl lb get-pool --name '$TUNNEL_NAME_AZ_B' | jq -r '.origins[0].address')
         [ \"\$origin\" = '${tunnel_id_b}.cfargotunnel.com' ]
     " || fail "pool az-b origin mismatch"
     pass "Pool az-b origin correct"
@@ -196,8 +200,8 @@ EOF
 
     # Verify both tunnel configs have the hostname (HA: full ingress on every tunnel).
     local tunnel_id_a tunnel_id_b
-    tunnel_id_a=$(cfgwctl tunnel get-id --name "${TUNNEL_PREFIX}-az-a" | jq -r '.tunnelId')
-    tunnel_id_b=$(cfgwctl tunnel get-id --name "${TUNNEL_PREFIX}-az-b" | jq -r '.tunnelId')
+    tunnel_id_a=$(cfgwctl tunnel get-id --name "$TUNNEL_NAME_AZ_A" | jq -r '.tunnelId')
+    tunnel_id_b=$(cfgwctl tunnel get-id --name "$TUNNEL_NAME_AZ_B" | jq -r '.tunnelId')
 
     log "Verifying tunnel az-a has hostname..."
     retry 60 3 bash -c "cfgwctl tunnel get-config --tunnel-id '$tunnel_id_a' | jq -e '.[] | select(.hostname == \"$HOSTNAME_A\")' >/dev/null" \
@@ -251,8 +255,8 @@ EOF
 
     # Verify both tunnels have both hostnames.
     local tunnel_id_a tunnel_id_b
-    tunnel_id_a=$(cfgwctl tunnel get-id --name "${TUNNEL_PREFIX}-az-a" | jq -r '.tunnelId')
-    tunnel_id_b=$(cfgwctl tunnel get-id --name "${TUNNEL_PREFIX}-az-b" | jq -r '.tunnelId')
+    tunnel_id_a=$(cfgwctl tunnel get-id --name "$TUNNEL_NAME_AZ_A" | jq -r '.tunnelId')
+    tunnel_id_b=$(cfgwctl tunnel get-id --name "$TUNNEL_NAME_AZ_B" | jq -r '.tunnelId')
 
     log "Verifying tunnels have both hostnames..."
     retry 60 3 bash -c "cfgwctl tunnel get-config --tunnel-id '$tunnel_id_a' | jq -e '.[] | select(.hostname == \"$HOSTNAME_B\")' >/dev/null" \
@@ -275,8 +279,8 @@ test_ha_route_deletion() {
     kubectl delete httproute ha-route-a -n "$TEST_NS"
 
     local tunnel_id_a tunnel_id_b
-    tunnel_id_a=$(cfgwctl tunnel get-id --name "${TUNNEL_PREFIX}-az-a" | jq -r '.tunnelId')
-    tunnel_id_b=$(cfgwctl tunnel get-id --name "${TUNNEL_PREFIX}-az-b" | jq -r '.tunnelId')
+    tunnel_id_a=$(cfgwctl tunnel get-id --name "$TUNNEL_NAME_AZ_A" | jq -r '.tunnelId')
+    tunnel_id_b=$(cfgwctl tunnel get-id --name "$TUNNEL_NAME_AZ_B" | jq -r '.tunnelId')
 
     log "Verifying hostname A removed from tunnel configs..."
     retry 60 3 bash -c "! cfgwctl tunnel get-config --tunnel-id '$tunnel_id_a' | jq -e '.[] | select(.hostname == \"$HOSTNAME_A\")' >/dev/null 2>&1" \
@@ -321,22 +325,22 @@ test_ha_gateway_deletion() {
     # Verify all pools deleted.
     log "Verifying all pools deleted..."
     local pool_count
-    pool_count=$(cfgwctl lb list-pools --prefix "$TUNNEL_PREFIX" | jq 'length')
+    pool_count=$(cfgwctl lb list-pools --prefix 'gw-' | jq 'length')
     [ "$pool_count" -eq 0 ] || fail "expected 0 pools, got $pool_count"
     pass "All pools deleted"
 
     # Verify monitor deleted.
     log "Verifying monitor deleted..."
     local monitor_id
-    monitor_id=$(cfgwctl lb get-monitor --name "$TUNNEL_PREFIX" | jq -r '.monitorId')
+    monitor_id=$(cfgwctl lb get-monitor --name "$MONITOR_NAME" | jq -r '.monitorId')
     [ -z "$monitor_id" ] || [ "$monitor_id" = "" ] || fail "monitor still exists: $monitor_id"
     pass "Monitor deleted"
 
     # Verify all tunnels deleted.
     log "Verifying all tunnels deleted..."
     local tunnel_a tunnel_b
-    tunnel_a=$(cfgwctl tunnel get-id --name "${TUNNEL_PREFIX}-az-a" | jq -r '.tunnelId')
-    tunnel_b=$(cfgwctl tunnel get-id --name "${TUNNEL_PREFIX}-az-b" | jq -r '.tunnelId')
+    tunnel_a=$(cfgwctl tunnel get-id --name "$TUNNEL_NAME_AZ_A" | jq -r '.tunnelId')
+    tunnel_b=$(cfgwctl tunnel get-id --name "$TUNNEL_NAME_AZ_B" | jq -r '.tunnelId')
     { [ -z "$tunnel_a" ] || [ "$tunnel_a" = "null" ]; } || fail "tunnel az-a still exists"
     { [ -z "$tunnel_b" ] || [ "$tunnel_b" = "null" ]; } || fail "tunnel az-b still exists"
     pass "All tunnels deleted"
@@ -492,9 +496,8 @@ EOF
         || fail "coex-simple-gw did not become Programmed"
     pass "coex-simple-gw is Programmed"
 
-    local simple_gw_uid simple_tunnel_name simple_tunnel_id simple_tunnel_target
-    simple_gw_uid=$(kubectl get gateway coex-simple-gw -n "$TEST_NS" -o jsonpath='{.metadata.uid}')
-    simple_tunnel_name="gateway-${simple_gw_uid}"
+    local simple_tunnel_name simple_tunnel_id simple_tunnel_target
+    simple_tunnel_name=$(cf_resource_name "$KIND_CLUSTER_NAME" "$TEST_NS" "coex-simple-gw")
     simple_tunnel_id=$(cfgwctl tunnel get-id --name "$simple_tunnel_name" | jq -r '.tunnelId')
     [ -n "$simple_tunnel_id" ] && [ "$simple_tunnel_id" != "null" ] || fail "simple tunnel not found"
     simple_tunnel_target="${simple_tunnel_id}.cfargotunnel.com"

--- a/hack/e2e-test-ts-az.sh
+++ b/hack/e2e-test-ts-az.sh
@@ -36,8 +36,8 @@ create_test_namespace
 ensure_gatewayclass
 
 # ─── Shared state across tests ───────────────────────────────────────────────
-GW_UID=""
-TUNNEL_PREFIX=""
+GW_NAME="tsaz-gw"
+MONITOR_NAME=""
 ZONE_ID=""
 HOSTNAME_A=""
 HOSTNAME_B=""
@@ -98,8 +98,7 @@ EOF
         || fail "tsaz-gw did not become Programmed"
     pass "tsaz-gw is Programmed"
 
-    GW_UID=$(kubectl get gateway tsaz-gw -n "$TEST_NS" -o jsonpath='{.metadata.uid}')
-    TUNNEL_PREFIX="gateway-${GW_UID}"
+    MONITOR_NAME=$(cf_resource_name "$KIND_CLUSTER_NAME" "$TEST_NS" "$GW_NAME" "monitor")
 
     HOSTNAME_A="tsaz-a-${TS: -6}.${TEST_ZONE_NAME}"
 
@@ -144,7 +143,8 @@ EOF
     local tunnel_ids=()
     for svc in svc-alpha svc-beta; do
         for az in az-a az-b; do
-            local tunnel_name="${TUNNEL_PREFIX}-${svc}-${az}"
+            local tunnel_name
+            tunnel_name=$(cf_resource_name "$KIND_CLUSTER_NAME" "$TEST_NS" "$GW_NAME" "$TEST_NS" "$svc" "$az")
             log "Verifying tunnel '${svc}-${az}'..."
             retry 60 3 bash -c "
                 id=\$(cfgwctl tunnel get-id --name '$tunnel_name' | jq -r '.tunnelId')
@@ -175,9 +175,12 @@ EOF
 
     # Verify each tunnel config routes to its own service only.
     log "Verifying tunnel ingress rules are service-specific..."
+    local tn_alpha_a tn_beta_a
+    tn_alpha_a=$(cf_resource_name "$KIND_CLUSTER_NAME" "$TEST_NS" "$GW_NAME" "$TEST_NS" "svc-alpha" "az-a")
+    tn_beta_a=$(cf_resource_name "$KIND_CLUSTER_NAME" "$TEST_NS" "$GW_NAME" "$TEST_NS" "svc-beta" "az-a")
     local tunnel_id_alpha_a tunnel_id_beta_a
-    tunnel_id_alpha_a=$(cfgwctl tunnel get-id --name "${TUNNEL_PREFIX}-svc-alpha-az-a" | jq -r '.tunnelId')
-    tunnel_id_beta_a=$(cfgwctl tunnel get-id --name "${TUNNEL_PREFIX}-svc-beta-az-a" | jq -r '.tunnelId')
+    tunnel_id_alpha_a=$(cfgwctl tunnel get-id --name "$tn_alpha_a" | jq -r '.tunnelId')
+    tunnel_id_beta_a=$(cfgwctl tunnel get-id --name "$tn_beta_a" | jq -r '.tunnelId')
 
     retry 60 3 bash -c "cfgwctl tunnel get-config --tunnel-id '$tunnel_id_alpha_a' | jq -e '.[] | select(.hostname == \"$HOSTNAME_A\")' >/dev/null" \
         || fail "tunnel svc-alpha-az-a missing hostname $HOSTNAME_A"
@@ -196,41 +199,46 @@ EOF
     # Verify monitor exists.
     log "Verifying monitor exists..."
     retry 60 3 bash -c "
-        id=\$(cfgwctl lb get-monitor --name '$TUNNEL_PREFIX' | jq -r '.monitorId')
+        id=\$(cfgwctl lb get-monitor --name '$MONITOR_NAME' | jq -r '.monitorId')
         [ -n \"\$id\" ] && [ \"\$id\" != '' ]
     " || fail "monitor not found"
     local monitor_id
-    monitor_id=$(cfgwctl lb get-monitor --name "$TUNNEL_PREFIX" | jq -r '.monitorId')
+    monitor_id=$(cfgwctl lb get-monitor --name "$MONITOR_NAME" | jq -r '.monitorId')
     pass "Monitor exists: $monitor_id"
 
     # Verify 2 pools (one per service), each with 2 origins (one per AZ).
     log "Verifying pools exist..."
-    retry 60 3 bash -c "[ \$(cfgwctl lb list-pools --prefix '$TUNNEL_PREFIX' | jq 'length') -eq 2 ]" \
+    retry 60 3 bash -c "[ \$(cfgwctl lb list-pools --prefix 'gw-' | jq 'length') -eq 2 ]" \
         || fail "expected 2 pools"
     pass "2 pools exist"
 
     # Verify pool svc-alpha has 2 origins.
+    local pn_alpha pn_beta
+    pn_alpha=$(cf_resource_name "$KIND_CLUSTER_NAME" "$TEST_NS" "$GW_NAME" "$TEST_NS" "svc-alpha")
+    pn_beta=$(cf_resource_name "$KIND_CLUSTER_NAME" "$TEST_NS" "$GW_NAME" "$TEST_NS" "svc-beta")
     log "Verifying pool svc-alpha has 2 origins..."
-    retry 60 3 bash -c "[ \$(cfgwctl lb get-pool --name '${TUNNEL_PREFIX}-svc-alpha' | jq '.origins | length') -eq 2 ]" \
+    retry 60 3 bash -c "[ \$(cfgwctl lb get-pool --name '$pn_alpha' | jq '.origins | length') -eq 2 ]" \
         || fail "expected 2 origins in pool svc-alpha"
     pass "Pool svc-alpha has 2 origins"
 
     # Verify pool svc-beta has 2 origins.
     log "Verifying pool svc-beta has 2 origins..."
-    retry 60 3 bash -c "[ \$(cfgwctl lb get-pool --name '${TUNNEL_PREFIX}-svc-beta' | jq '.origins | length') -eq 2 ]" \
+    retry 60 3 bash -c "[ \$(cfgwctl lb get-pool --name '$pn_beta' | jq '.origins | length') -eq 2 ]" \
         || fail "expected 2 origins in pool svc-beta"
     pass "Pool svc-beta has 2 origins"
 
     # Verify pool origins reference the correct tunnels.
     log "Verifying pool svc-alpha origins reference correct tunnels..."
     local alpha_az_a_tid alpha_az_b_tid
-    alpha_az_a_tid=$(cfgwctl tunnel get-id --name "${TUNNEL_PREFIX}-svc-alpha-az-a" | jq -r '.tunnelId')
-    alpha_az_b_tid=$(cfgwctl tunnel get-id --name "${TUNNEL_PREFIX}-svc-alpha-az-b" | jq -r '.tunnelId')
+    alpha_az_a_tid=$(cfgwctl tunnel get-id --name "$tn_alpha_a" | jq -r '.tunnelId')
+    local tn_alpha_b
+    tn_alpha_b=$(cf_resource_name "$KIND_CLUSTER_NAME" "$TEST_NS" "$GW_NAME" "$TEST_NS" "svc-alpha" "az-b")
+    alpha_az_b_tid=$(cfgwctl tunnel get-id --name "$tn_alpha_b" | jq -r '.tunnelId')
 
-    retry 60 3 bash -c "cfgwctl lb get-pool --name '${TUNNEL_PREFIX}-svc-alpha' \
+    retry 60 3 bash -c "cfgwctl lb get-pool --name '$pn_alpha' \
         | jq -e '.origins[] | select(.address == \"${alpha_az_a_tid}.cfargotunnel.com\")' >/dev/null" \
         || fail "pool svc-alpha missing origin for az-a"
-    retry 60 3 bash -c "cfgwctl lb get-pool --name '${TUNNEL_PREFIX}-svc-alpha' \
+    retry 60 3 bash -c "cfgwctl lb get-pool --name '$pn_alpha' \
         | jq -e '.origins[] | select(.address == \"${alpha_az_b_tid}.cfargotunnel.com\")' >/dev/null" \
         || fail "pool svc-alpha missing origin for az-b"
     pass "Pool svc-alpha origins correct"
@@ -269,8 +277,10 @@ EOF
 
     # No new tunnels/pools needed — svc-alpha already has tunnels and a pool.
     # Verify svc-alpha tunnel az-a has both hostnames.
+    local tn_alpha_a
+    tn_alpha_a=$(cf_resource_name "$KIND_CLUSTER_NAME" "$TEST_NS" "$GW_NAME" "$TEST_NS" "svc-alpha" "az-a")
     local tunnel_id_alpha_a
-    tunnel_id_alpha_a=$(cfgwctl tunnel get-id --name "${TUNNEL_PREFIX}-svc-alpha-az-a" | jq -r '.tunnelId')
+    tunnel_id_alpha_a=$(cfgwctl tunnel get-id --name "$tn_alpha_a" | jq -r '.tunnelId')
     log "Verifying svc-alpha-az-a tunnel has both hostnames..."
     retry 60 3 bash -c "cfgwctl tunnel get-config --tunnel-id '$tunnel_id_alpha_a' | jq -e '.[] | select(.hostname == \"$HOSTNAME_B\")' >/dev/null" \
         || fail "tunnel svc-alpha-az-a missing hostname $HOSTNAME_B"
@@ -281,7 +291,7 @@ EOF
     # Still 2 pools (no new service was added).
     log "Verifying still 2 pools..."
     local pool_count
-    pool_count=$(cfgwctl lb list-pools --prefix "$TUNNEL_PREFIX" | jq 'length')
+    pool_count=$(cfgwctl lb list-pools --prefix 'gw-' | jq 'length')
     [ "$pool_count" -eq 2 ] || fail "expected 2 pools, got $pool_count"
     pass "2 pools still exist"
 
@@ -301,8 +311,10 @@ test_tsaz_route_deletion() {
     # svc-beta is no longer referenced → all its tunnels + Deployments should be deleted.
     log "Verifying svc-beta tunnels deleted..."
     for az in az-a az-b; do
+        local tn_beta_az
+        tn_beta_az=$(cf_resource_name "$KIND_CLUSTER_NAME" "$TEST_NS" "$GW_NAME" "$TEST_NS" "svc-beta" "$az")
         retry 60 3 bash -c "
-            id=\$(cfgwctl tunnel get-id --name '${TUNNEL_PREFIX}-svc-beta-${az}' | jq -r '.tunnelId')
+            id=\$(cfgwctl tunnel get-id --name '$tn_beta_az' | jq -r '.tunnelId')
             [ -z \"\$id\" ] || [ \"\$id\" = 'null' ]
         " || fail "tunnel svc-beta-${az} still exists"
         pass "Tunnel svc-beta-${az} deleted"
@@ -318,15 +330,19 @@ test_tsaz_route_deletion() {
     # svc-alpha tunnels should still exist (still referenced by route-b).
     log "Verifying svc-alpha tunnels still exist..."
     for az in az-a az-b; do
+        local tn_alpha_az
+        tn_alpha_az=$(cf_resource_name "$KIND_CLUSTER_NAME" "$TEST_NS" "$GW_NAME" "$TEST_NS" "svc-alpha" "$az")
         local tid
-        tid=$(cfgwctl tunnel get-id --name "${TUNNEL_PREFIX}-svc-alpha-${az}" | jq -r '.tunnelId')
+        tid=$(cfgwctl tunnel get-id --name "$tn_alpha_az" | jq -r '.tunnelId')
         [ -n "$tid" ] && [ "$tid" != "null" ] || fail "tunnel svc-alpha-${az} disappeared"
     done
     pass "All svc-alpha tunnels still exist"
 
     # Verify svc-alpha tunnel only has hostname B now.
+    local tn_alpha_a
+    tn_alpha_a=$(cf_resource_name "$KIND_CLUSTER_NAME" "$TEST_NS" "$GW_NAME" "$TEST_NS" "svc-alpha" "az-a")
     local tunnel_id_alpha_a
-    tunnel_id_alpha_a=$(cfgwctl tunnel get-id --name "${TUNNEL_PREFIX}-svc-alpha-az-a" | jq -r '.tunnelId')
+    tunnel_id_alpha_a=$(cfgwctl tunnel get-id --name "$tn_alpha_a" | jq -r '.tunnelId')
     log "Verifying svc-alpha-az-a tunnel has only hostname B..."
     retry 60 3 bash -c "! cfgwctl tunnel get-config --tunnel-id '$tunnel_id_alpha_a' | jq -e '.[] | select(.hostname == \"$HOSTNAME_A\")' >/dev/null 2>&1" \
         || fail "tunnel svc-alpha-az-a still has hostname $HOSTNAME_A"
@@ -347,8 +363,10 @@ test_tsaz_route_deletion() {
 
     # Verify pool svc-beta deleted, pool svc-alpha still exists.
     log "Verifying pool svc-beta deleted..."
+    local pn_beta
+    pn_beta=$(cf_resource_name "$KIND_CLUSTER_NAME" "$TEST_NS" "$GW_NAME" "$TEST_NS" "svc-beta")
     local pool_beta_id
-    pool_beta_id=$(cfgwctl lb get-pool --name "${TUNNEL_PREFIX}-svc-beta" | jq -r '.poolId')
+    pool_beta_id=$(cfgwctl lb get-pool --name "$pn_beta" | jq -r '.poolId')
     { [ -z "$pool_beta_id" ] || [ "$pool_beta_id" = "" ]; } || fail "pool svc-beta still exists"
     pass "Pool svc-beta deleted"
 
@@ -378,14 +396,14 @@ test_tsaz_gateway_deletion() {
     # Verify all pools deleted.
     log "Verifying all pools deleted..."
     local pool_count
-    pool_count=$(cfgwctl lb list-pools --prefix "$TUNNEL_PREFIX" | jq 'length')
+    pool_count=$(cfgwctl lb list-pools --prefix 'gw-' | jq 'length')
     [ "$pool_count" -eq 0 ] || fail "expected 0 pools, got $pool_count"
     pass "All pools deleted"
 
     # Verify monitor deleted.
     log "Verifying monitor deleted..."
     local monitor_id
-    monitor_id=$(cfgwctl lb get-monitor --name "$TUNNEL_PREFIX" | jq -r '.monitorId')
+    monitor_id=$(cfgwctl lb get-monitor --name "$MONITOR_NAME" | jq -r '.monitorId')
     [ -z "$monitor_id" ] || [ "$monitor_id" = "" ] || fail "monitor still exists: $monitor_id"
     pass "Monitor deleted"
 
@@ -393,8 +411,10 @@ test_tsaz_gateway_deletion() {
     log "Verifying all tunnels deleted..."
     for svc in svc-alpha; do
         for az in az-a az-b; do
+            local tn
+            tn=$(cf_resource_name "$KIND_CLUSTER_NAME" "$TEST_NS" "$GW_NAME" "$TEST_NS" "$svc" "$az")
             local tid
-            tid=$(cfgwctl tunnel get-id --name "${TUNNEL_PREFIX}-${svc}-${az}" | jq -r '.tunnelId')
+            tid=$(cfgwctl tunnel get-id --name "$tn" | jq -r '.tunnelId')
             { [ -z "$tid" ] || [ "$tid" = "null" ]; } || fail "tunnel ${svc}-${az} still exists"
         done
     done

--- a/hack/e2e-test-ts.sh
+++ b/hack/e2e-test-ts.sh
@@ -33,8 +33,14 @@ ensure_gatewayclass
 
 # ─── Shared state across tests ───────────────────────────────────────────────
 # These are populated by test_ts_basic and used by subsequent tests.
-GW_UID=""
-TUNNEL_PREFIX=""
+GW_NAME="ts-gw"
+TUNNEL_NAME_ALPHA=""
+TUNNEL_NAME_BETA=""
+TUNNEL_NAME_GAMMA=""
+POOL_NAME_ALPHA=""
+POOL_NAME_BETA=""
+POOL_NAME_GAMMA=""
+MONITOR_NAME=""
 ZONE_ID=""
 HOSTNAME_A=""
 HOSTNAME_B=""
@@ -89,8 +95,13 @@ EOF
         || fail "ts-gw did not become Programmed"
     pass "ts-gw is Programmed"
 
-    GW_UID=$(kubectl get gateway ts-gw -n "$TEST_NS" -o jsonpath='{.metadata.uid}')
-    TUNNEL_PREFIX="gateway-${GW_UID}"
+    TUNNEL_NAME_ALPHA=$(cf_resource_name "$KIND_CLUSTER_NAME" "$TEST_NS" "$GW_NAME" "$TEST_NS" "svc-alpha")
+    TUNNEL_NAME_BETA=$(cf_resource_name "$KIND_CLUSTER_NAME" "$TEST_NS" "$GW_NAME" "$TEST_NS" "svc-beta")
+    TUNNEL_NAME_GAMMA=$(cf_resource_name "$KIND_CLUSTER_NAME" "$TEST_NS" "$GW_NAME" "$TEST_NS" "svc-gamma")
+    POOL_NAME_ALPHA="$TUNNEL_NAME_ALPHA"
+    POOL_NAME_BETA="$TUNNEL_NAME_BETA"
+    POOL_NAME_GAMMA="$TUNNEL_NAME_GAMMA"
+    MONITOR_NAME=$(cf_resource_name "$KIND_CLUSTER_NAME" "$TEST_NS" "$GW_NAME" "monitor")
 
     HOSTNAME_A="ts-a-${TS: -6}.${TEST_ZONE_NAME}"
 
@@ -135,18 +146,18 @@ EOF
     local tunnel_id_alpha tunnel_id_beta
     log "Verifying tunnel for svc-alpha..."
     retry 60 3 bash -c "
-        id=\$(cfgwctl tunnel get-id --name '${TUNNEL_PREFIX}-svc-alpha' | jq -r '.tunnelId')
+        id=\$(cfgwctl tunnel get-id --name '$TUNNEL_NAME_ALPHA' | jq -r '.tunnelId')
         [ -n \"\$id\" ] && [ \"\$id\" != 'null' ]
     " || fail "tunnel svc-alpha not found"
-    tunnel_id_alpha=$(cfgwctl tunnel get-id --name "${TUNNEL_PREFIX}-svc-alpha" | jq -r '.tunnelId')
+    tunnel_id_alpha=$(cfgwctl tunnel get-id --name "$TUNNEL_NAME_ALPHA" | jq -r '.tunnelId')
     pass "Tunnel svc-alpha exists: $tunnel_id_alpha"
 
     log "Verifying tunnel for svc-beta..."
     retry 60 3 bash -c "
-        id=\$(cfgwctl tunnel get-id --name '${TUNNEL_PREFIX}-svc-beta' | jq -r '.tunnelId')
+        id=\$(cfgwctl tunnel get-id --name '$TUNNEL_NAME_BETA' | jq -r '.tunnelId')
         [ -n \"\$id\" ] && [ \"\$id\" != 'null' ]
     " || fail "tunnel svc-beta not found"
-    tunnel_id_beta=$(cfgwctl tunnel get-id --name "${TUNNEL_PREFIX}-svc-beta" | jq -r '.tunnelId')
+    tunnel_id_beta=$(cfgwctl tunnel get-id --name "$TUNNEL_NAME_BETA" | jq -r '.tunnelId')
     pass "Tunnel svc-beta exists: $tunnel_id_beta"
 
     # Verify 2 Deployments.
@@ -177,30 +188,30 @@ EOF
     # Verify monitor exists.
     log "Verifying monitor exists..."
     retry 60 3 bash -c "
-        id=\$(cfgwctl lb get-monitor --name '$TUNNEL_PREFIX' | jq -r '.monitorId')
+        id=\$(cfgwctl lb get-monitor --name '$MONITOR_NAME' | jq -r '.monitorId')
         [ -n \"\$id\" ] && [ \"\$id\" != '' ]
     " || fail "monitor not found"
     local monitor_id
-    monitor_id=$(cfgwctl lb get-monitor --name "$TUNNEL_PREFIX" | jq -r '.monitorId')
+    monitor_id=$(cfgwctl lb get-monitor --name "$MONITOR_NAME" | jq -r '.monitorId')
     pass "Monitor exists: $monitor_id"
 
     # Verify 2 pools (one per service).
     log "Verifying pools exist..."
-    retry 60 3 bash -c "[ \$(cfgwctl lb list-pools --prefix '$TUNNEL_PREFIX' | jq 'length') -eq 2 ]" \
+    retry 60 3 bash -c "[ \$(cfgwctl lb list-pools --prefix 'gw-' | jq 'length') -eq 2 ]" \
         || fail "expected 2 pools"
     pass "2 pools exist"
 
     # Verify pool origins point to correct tunnels.
     log "Verifying pool svc-alpha origin..."
     retry 60 3 bash -c "
-        origin=\$(cfgwctl lb get-pool --name '${TUNNEL_PREFIX}-svc-alpha' | jq -r '.origins[0].address')
+        origin=\$(cfgwctl lb get-pool --name '$POOL_NAME_ALPHA' | jq -r '.origins[0].address')
         [ \"\$origin\" = '${tunnel_id_alpha}.cfargotunnel.com' ]
     " || fail "pool svc-alpha origin mismatch"
     pass "Pool svc-alpha origin correct"
 
     log "Verifying pool svc-beta origin..."
     retry 60 3 bash -c "
-        origin=\$(cfgwctl lb get-pool --name '${TUNNEL_PREFIX}-svc-beta' | jq -r '.origins[0].address')
+        origin=\$(cfgwctl lb get-pool --name '$POOL_NAME_BETA' | jq -r '.origins[0].address')
         [ \"\$origin\" = '${tunnel_id_beta}.cfargotunnel.com' ]
     " || fail "pool svc-beta origin mismatch"
     pass "Pool svc-beta origin correct"
@@ -257,11 +268,11 @@ EOF
     # Verify 3rd tunnel created for svc-gamma.
     log "Verifying tunnel for svc-gamma..."
     retry 60 3 bash -c "
-        id=\$(cfgwctl tunnel get-id --name '${TUNNEL_PREFIX}-svc-gamma' | jq -r '.tunnelId')
+        id=\$(cfgwctl tunnel get-id --name '$TUNNEL_NAME_GAMMA' | jq -r '.tunnelId')
         [ -n \"\$id\" ] && [ \"\$id\" != 'null' ]
     " || fail "tunnel svc-gamma not found"
     local tunnel_id_gamma
-    tunnel_id_gamma=$(cfgwctl tunnel get-id --name "${TUNNEL_PREFIX}-svc-gamma" | jq -r '.tunnelId')
+    tunnel_id_gamma=$(cfgwctl tunnel get-id --name "$TUNNEL_NAME_GAMMA" | jq -r '.tunnelId')
     pass "Tunnel svc-gamma exists: $tunnel_id_gamma"
 
     # Verify 3rd Deployment created.
@@ -272,21 +283,21 @@ EOF
 
     # Verify 3 pools total.
     log "Verifying 3 pools exist..."
-    retry 60 3 bash -c "[ \$(cfgwctl lb list-pools --prefix '$TUNNEL_PREFIX' | jq 'length') -eq 3 ]" \
+    retry 60 3 bash -c "[ \$(cfgwctl lb list-pools --prefix 'gw-' | jq 'length') -eq 3 ]" \
         || fail "expected 3 pools"
     pass "3 pools exist"
 
     # Verify svc-gamma pool origin.
     log "Verifying pool svc-gamma origin..."
     local pool_gamma_origin
-    pool_gamma_origin=$(cfgwctl lb get-pool --name "${TUNNEL_PREFIX}-svc-gamma" | jq -r '.origins[0].address')
+    pool_gamma_origin=$(cfgwctl lb get-pool --name "$POOL_NAME_GAMMA" | jq -r '.origins[0].address')
     [ "$pool_gamma_origin" = "${tunnel_id_gamma}.cfargotunnel.com" ] \
         || fail "pool svc-gamma origin mismatch: got $pool_gamma_origin, want ${tunnel_id_gamma}.cfargotunnel.com"
     pass "Pool svc-gamma origin correct"
 
     # Verify svc-alpha tunnel config now has BOTH hostnames.
     local tunnel_id_alpha
-    tunnel_id_alpha=$(cfgwctl tunnel get-id --name "${TUNNEL_PREFIX}-svc-alpha" | jq -r '.tunnelId')
+    tunnel_id_alpha=$(cfgwctl tunnel get-id --name "$TUNNEL_NAME_ALPHA" | jq -r '.tunnelId')
     log "Verifying svc-alpha tunnel has both hostnames..."
     retry 60 3 bash -c "cfgwctl tunnel get-config --tunnel-id '$tunnel_id_alpha' | jq -e '.[] | select(.hostname == \"$HOSTNAME_B\")' >/dev/null" \
         || fail "tunnel svc-alpha missing hostname $HOSTNAME_B"
@@ -310,7 +321,7 @@ test_ts_route_deletion() {
     # svc-beta is no longer referenced by any route → tunnel + Deployment should be deleted.
     log "Verifying svc-beta tunnel deleted..."
     retry 60 3 bash -c "
-        id=\$(cfgwctl tunnel get-id --name '${TUNNEL_PREFIX}-svc-beta' | jq -r '.tunnelId')
+        id=\$(cfgwctl tunnel get-id --name '$TUNNEL_NAME_BETA' | jq -r '.tunnelId')
         [ -z \"\$id\" ] || [ \"\$id\" = 'null' ]
     " || fail "tunnel svc-beta still exists"
     pass "Tunnel svc-beta deleted"
@@ -323,7 +334,7 @@ test_ts_route_deletion() {
     # svc-alpha is still referenced by ts-route-b → should still exist.
     log "Verifying svc-alpha tunnel still exists..."
     local tunnel_id_alpha
-    tunnel_id_alpha=$(cfgwctl tunnel get-id --name "${TUNNEL_PREFIX}-svc-alpha" | jq -r '.tunnelId')
+    tunnel_id_alpha=$(cfgwctl tunnel get-id --name "$TUNNEL_NAME_ALPHA" | jq -r '.tunnelId')
     [ -n "$tunnel_id_alpha" ] && [ "$tunnel_id_alpha" != "null" ] || fail "tunnel svc-alpha disappeared"
     pass "Tunnel svc-alpha still exists"
 
@@ -353,7 +364,7 @@ test_ts_route_deletion() {
     # Verify pool svc-beta deleted.
     log "Verifying pool svc-beta deleted..."
     local pool_beta_id
-    pool_beta_id=$(cfgwctl lb get-pool --name "${TUNNEL_PREFIX}-svc-beta" | jq -r '.poolId')
+    pool_beta_id=$(cfgwctl lb get-pool --name "$POOL_NAME_BETA" | jq -r '.poolId')
     { [ -z "$pool_beta_id" ] || [ "$pool_beta_id" = "" ]; } || fail "pool svc-beta still exists"
     pass "Pool svc-beta deleted"
 
@@ -383,22 +394,22 @@ test_ts_gateway_deletion() {
     # Verify all pools deleted.
     log "Verifying all pools deleted..."
     local pool_count
-    pool_count=$(cfgwctl lb list-pools --prefix "$TUNNEL_PREFIX" | jq 'length')
+    pool_count=$(cfgwctl lb list-pools --prefix 'gw-' | jq 'length')
     [ "$pool_count" -eq 0 ] || fail "expected 0 pools, got $pool_count"
     pass "All pools deleted"
 
     # Verify monitor deleted.
     log "Verifying monitor deleted..."
     local monitor_id
-    monitor_id=$(cfgwctl lb get-monitor --name "$TUNNEL_PREFIX" | jq -r '.monitorId')
+    monitor_id=$(cfgwctl lb get-monitor --name "$MONITOR_NAME" | jq -r '.monitorId')
     [ -z "$monitor_id" ] || [ "$monitor_id" = "" ] || fail "monitor still exists: $monitor_id"
     pass "Monitor deleted"
 
     # Verify all tunnels deleted.
     log "Verifying all tunnels deleted..."
-    local tunnel_alpha tunnel_beta tunnel_gamma
-    tunnel_alpha=$(cfgwctl tunnel get-id --name "${TUNNEL_PREFIX}-svc-alpha" | jq -r '.tunnelId')
-    tunnel_gamma=$(cfgwctl tunnel get-id --name "${TUNNEL_PREFIX}-svc-gamma" | jq -r '.tunnelId')
+    local tunnel_alpha tunnel_gamma
+    tunnel_alpha=$(cfgwctl tunnel get-id --name "$TUNNEL_NAME_ALPHA" | jq -r '.tunnelId')
+    tunnel_gamma=$(cfgwctl tunnel get-id --name "$TUNNEL_NAME_GAMMA" | jq -r '.tunnelId')
     { [ -z "$tunnel_alpha" ] || [ "$tunnel_alpha" = "null" ]; } || fail "tunnel svc-alpha still exists"
     { [ -z "$tunnel_gamma" ] || [ "$tunnel_gamma" = "null" ]; } || fail "tunnel svc-gamma still exists"
     pass "All tunnels deleted"

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -84,10 +84,9 @@ EOF
         || fail "Gateway did not become Programmed"
     pass "Gateway is Programmed"
 
-    # Get tunnel name from Gateway UID.
-    local gw_uid tunnel_name tunnel_id
-    gw_uid=$(kubectl get gateway test-gateway -n "$TEST_NS" -o jsonpath='{.metadata.uid}')
-    tunnel_name="gateway-${gw_uid}"
+    # Get deterministic tunnel name.
+    local tunnel_name tunnel_id
+    tunnel_name=$(cf_resource_name "$KIND_CLUSTER_NAME" "$TEST_NS" "test-gateway")
 
     log "Verifying tunnel '$tunnel_name' exists..."
     tunnel_id=$(cfgwctl tunnel get-id --name "$tunnel_name" | jq -r '.tunnelId')
@@ -235,9 +234,8 @@ EOF
         || fail "multi-route-gw did not become Programmed"
     pass "multi-route-gw is Programmed"
 
-    local mr_gw_uid mr_tunnel_name mr_tunnel_id mr_tunnel_target
-    mr_gw_uid=$(kubectl get gateway multi-route-gw -n "$TEST_NS" -o jsonpath='{.metadata.uid}')
-    mr_tunnel_name="gateway-${mr_gw_uid}"
+    local mr_tunnel_name mr_tunnel_id mr_tunnel_target
+    mr_tunnel_name=$(cf_resource_name "$KIND_CLUSTER_NAME" "$TEST_NS" "multi-route-gw")
     mr_tunnel_id=$(cfgwctl tunnel get-id --name "$mr_tunnel_name" | jq -r '.tunnelId')
     [ -n "$mr_tunnel_id" ] && [ "$mr_tunnel_id" != "null" ] || fail "multi-route tunnel not found"
     mr_tunnel_target="${mr_tunnel_id}.cfargotunnel.com"
@@ -368,9 +366,8 @@ EOF
         || fail "path-gw did not become Programmed"
     pass "path-gw is Programmed"
 
-    local path_gw_uid path_tunnel_name path_tunnel_id
-    path_gw_uid=$(kubectl get gateway path-gw -n "$TEST_NS" -o jsonpath='{.metadata.uid}')
-    path_tunnel_name="gateway-${path_gw_uid}"
+    local path_tunnel_name path_tunnel_id
+    path_tunnel_name=$(cf_resource_name "$KIND_CLUSTER_NAME" "$TEST_NS" "path-gw")
     path_tunnel_id=$(cfgwctl tunnel get-id --name "$path_tunnel_name" | jq -r '.tunnelId')
     [ -n "$path_tunnel_id" ] && [ "$path_tunnel_id" != "null" ] || fail "path tunnel not found"
 
@@ -460,9 +457,8 @@ EOF
         || fail "no-dns-gw did not become Programmed"
     pass "no-dns-gw is Programmed"
 
-    local nd_gw_uid nd_tunnel_name nd_tunnel_id
-    nd_gw_uid=$(kubectl get gateway no-dns-gw -n "$TEST_NS" -o jsonpath='{.metadata.uid}')
-    nd_tunnel_name="gateway-${nd_gw_uid}"
+    local nd_tunnel_name nd_tunnel_id
+    nd_tunnel_name=$(cf_resource_name "$KIND_CLUSTER_NAME" "$TEST_NS" "no-dns-gw")
     nd_tunnel_id=$(cfgwctl tunnel get-id --name "$nd_tunnel_name" | jq -r '.tunnelId')
     [ -n "$nd_tunnel_id" ] && [ "$nd_tunnel_id" != "null" ] || fail "no-dns tunnel not found"
 
@@ -622,9 +618,8 @@ EOF
         || fail "disabled-gw did not become Programmed"
     pass "disabled-gw is Programmed"
 
-    local dis_gw_uid dis_tunnel_name dis_tunnel_id dis_tunnel_target
-    dis_gw_uid=$(kubectl get gateway disabled-gw -n "$TEST_NS" -o jsonpath='{.metadata.uid}')
-    dis_tunnel_name="gateway-${dis_gw_uid}"
+    local dis_tunnel_name dis_tunnel_id dis_tunnel_target
+    dis_tunnel_name=$(cf_resource_name "$KIND_CLUSTER_NAME" "$TEST_NS" "disabled-gw")
     dis_tunnel_id=$(cfgwctl tunnel get-id --name "$dis_tunnel_name" | jq -r '.tunnelId')
     [ -n "$dis_tunnel_id" ] && [ "$dis_tunnel_id" != "null" ] || fail "disabled tunnel not found"
     dis_tunnel_target="${dis_tunnel_id}.cfargotunnel.com"
@@ -747,9 +742,8 @@ EOF
         || fail "zone-rm-gw did not become Programmed"
     pass "zone-rm-gw is Programmed"
 
-    local zr_gw_uid zr_tunnel_name zr_tunnel_id zr_tunnel_target
-    zr_gw_uid=$(kubectl get gateway zone-rm-gw -n "$TEST_NS" -o jsonpath='{.metadata.uid}')
-    zr_tunnel_name="gateway-${zr_gw_uid}"
+    local zr_tunnel_name zr_tunnel_id zr_tunnel_target
+    zr_tunnel_name=$(cf_resource_name "$KIND_CLUSTER_NAME" "$TEST_NS" "zone-rm-gw")
     zr_tunnel_id=$(cfgwctl tunnel get-id --name "$zr_tunnel_name" | jq -r '.tunnelId')
     [ -n "$zr_tunnel_id" ] && [ "$zr_tunnel_id" != "null" ] || fail "zone-rm tunnel not found"
     zr_tunnel_target="${zr_tunnel_id}.cfargotunnel.com"
@@ -822,6 +816,247 @@ EOF
     kubectl delete service zone-rm-backend -n "$TEST_NS" --ignore-not-found
 }
 
+test_cluster_recreation() {
+    local test_hostname="rec-${TS: -6}.${TEST_ZONE_NAME}"
+
+    log "Phase 1: Create Gateway + HTTPRoute in current cluster..."
+
+    log "Creating CloudflareGatewayParameters 'recreate-params'..."
+    kubectl apply -f - <<EOF
+apiVersion: cloudflare-gateway-controller.io/v1
+kind: CloudflareGatewayParameters
+metadata:
+  name: recreate-params
+  namespace: $TEST_NS
+spec:
+  secretRef:
+    name: cloudflare-creds
+  dns:
+    zone:
+      name: "$TEST_ZONE_NAME"
+EOF
+
+    log "Creating Gateway 'recreate-gw'..."
+    kubectl apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: recreate-gw
+  namespace: $TEST_NS
+spec:
+  gatewayClassName: cloudflare
+  infrastructure:
+    parametersRef:
+      group: cloudflare-gateway-controller.io
+      kind: CloudflareGatewayParameters
+      name: recreate-params
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+EOF
+
+    retry 60 2 kubectl wait gateway/recreate-gw -n "$TEST_NS" \
+        --for=condition=Programmed --timeout=5s \
+        || fail "recreate-gw did not become Programmed"
+    pass "recreate-gw is Programmed"
+
+    local tunnel_name tunnel_id_before
+    tunnel_name=$(cf_resource_name "$KIND_CLUSTER_NAME" "$TEST_NS" "recreate-gw")
+
+    log "Verifying tunnel '$tunnel_name' exists..."
+    tunnel_id_before=$(cfgwctl tunnel get-id --name "$tunnel_name" | jq -r '.tunnelId')
+    [ -n "$tunnel_id_before" ] && [ "$tunnel_id_before" != "null" ] || fail "tunnel not found"
+    pass "Tunnel exists: $tunnel_id_before"
+
+    kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: recreate-backend
+  namespace: $TEST_NS
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+EOF
+
+    kubectl apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: recreate-route
+  namespace: $TEST_NS
+spec:
+  parentRefs:
+  - name: recreate-gw
+  hostnames:
+  - "$test_hostname"
+  rules:
+  - backendRefs:
+    - name: recreate-backend
+      port: 80
+EOF
+
+    log "Waiting for DNS CNAME for '$test_hostname'..."
+    local zone_id tunnel_target
+    zone_id=$(cfgwctl dns find-zone --hostname "$test_hostname" | jq -r '.zoneId')
+    [ -n "$zone_id" ] && [ "$zone_id" != "null" ] || fail "zone ID not found"
+    tunnel_target="${tunnel_id_before}.cfargotunnel.com"
+
+    retry 60 3 bash -c "cfgwctl dns list-cnames --zone-id '$zone_id' --target '$tunnel_target' | jq -e '.hostnames[] | select(. == \"$test_hostname\")' >/dev/null" \
+        || fail "DNS CNAME not found"
+    pass "DNS CNAME exists before cluster recreation"
+
+    log "Phase 2: Delete and recreate kind cluster..."
+
+    # Stop log stream before cluster deletion.
+    if [ -n "$_LOG_STREAM_PID" ]; then
+        kill "$_LOG_STREAM_PID" 2>/dev/null || true
+        wait "$_LOG_STREAM_PID" 2>/dev/null || true
+        _LOG_STREAM_PID=""
+    fi
+
+    kind delete cluster --name "$KIND_CLUSTER_NAME"
+    _CREATED_CLUSTER=0
+
+    # Force fresh cluster and controller install regardless of env vars.
+    local saved_reuse_cluster="${REUSE_CLUSTER:-}"
+    local saved_reuse_controller="${REUSE_CONTROLLER:-}"
+    local saved_reload_controller="${RELOAD_CONTROLLER:-}"
+    REUSE_CLUSTER=""
+    REUSE_CONTROLLER=""
+    RELOAD_CONTROLLER=""
+
+    setup_cluster
+    install_controller
+    start_controller_log_stream
+    create_test_namespace
+    ensure_gatewayclass
+
+    # Restore env vars.
+    REUSE_CLUSTER="$saved_reuse_cluster"
+    REUSE_CONTROLLER="$saved_reuse_controller"
+    RELOAD_CONTROLLER="$saved_reload_controller"
+
+    log "Phase 3: Recreate same Gateway + HTTPRoute..."
+
+    kubectl apply -f - <<EOF
+apiVersion: cloudflare-gateway-controller.io/v1
+kind: CloudflareGatewayParameters
+metadata:
+  name: recreate-params
+  namespace: $TEST_NS
+spec:
+  secretRef:
+    name: cloudflare-creds
+  dns:
+    zone:
+      name: "$TEST_ZONE_NAME"
+EOF
+
+    kubectl apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: recreate-gw
+  namespace: $TEST_NS
+spec:
+  gatewayClassName: cloudflare
+  infrastructure:
+    parametersRef:
+      group: cloudflare-gateway-controller.io
+      kind: CloudflareGatewayParameters
+      name: recreate-params
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+EOF
+
+    retry 60 2 kubectl wait gateway/recreate-gw -n "$TEST_NS" \
+        --for=condition=Programmed --timeout=5s \
+        || fail "recreate-gw did not become Programmed after cluster recreation"
+    pass "recreate-gw is Programmed after cluster recreation"
+
+    kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: recreate-backend
+  namespace: $TEST_NS
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+EOF
+
+    kubectl apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: recreate-route
+  namespace: $TEST_NS
+spec:
+  parentRefs:
+  - name: recreate-gw
+  hostnames:
+  - "$test_hostname"
+  rules:
+  - backendRefs:
+    - name: recreate-backend
+      port: 80
+EOF
+
+    log "Phase 4: Verify tunnel adoption..."
+
+    local tunnel_id_after
+    tunnel_id_after=$(cfgwctl tunnel get-id --name "$tunnel_name" | jq -r '.tunnelId')
+    [ -n "$tunnel_id_after" ] && [ "$tunnel_id_after" != "null" ] || fail "tunnel not found after recreation"
+    [ "$tunnel_id_before" = "$tunnel_id_after" ] \
+        || fail "tunnel ID changed: before=$tunnel_id_before after=$tunnel_id_after (resource leaked!)"
+    pass "Tunnel adopted: same ID $tunnel_id_before"
+
+    log "Verifying tunnel config has hostname after adoption..."
+    retry 60 3 bash -c "cfgwctl tunnel get-config --tunnel-id '$tunnel_id_after' | jq -e '.[] | select(.hostname == \"$test_hostname\")' >/dev/null" \
+        || fail "tunnel config missing hostname after adoption"
+    pass "Tunnel config has hostname after adoption"
+
+    log "Verifying DNS CNAME still exists after adoption..."
+    retry 60 3 bash -c "cfgwctl dns list-cnames --zone-id '$zone_id' --target '$tunnel_target' | jq -e '.hostnames[] | select(. == \"$test_hostname\")' >/dev/null" \
+        || fail "DNS CNAME not found after adoption"
+    pass "DNS CNAME exists after adoption"
+
+    log "Phase 5: Clean up via normal Gateway finalization..."
+
+    kubectl delete httproute recreate-route -n "$TEST_NS"
+    kubectl delete gateway recreate-gw -n "$TEST_NS"
+
+    retry 60 3 bash -c "! kubectl get gateway recreate-gw -n '$TEST_NS' 2>/dev/null" \
+        || fail "recreate-gw still exists"
+    pass "Gateway deleted"
+
+    log "Verifying tunnel deleted by finalizer..."
+    check_tunnel_deleted() {
+        local id
+        id=$(cfgwctl tunnel get-id --name "$tunnel_name" | jq -r '.tunnelId')
+        [ -z "$id" ] || [ "$id" = "null" ]
+    }
+    retry 60 3 check_tunnel_deleted || fail "tunnel still exists after finalization"
+    pass "Tunnel deleted by finalizer"
+
+    log "Verifying DNS CNAME deleted..."
+    check_cname_deleted() {
+        ! cfgwctl dns list-cnames --zone-id "$zone_id" --target "$tunnel_target" \
+            | jq -e ".hostnames[] | select(. == \"$test_hostname\")" >/dev/null 2>&1
+    }
+    retry 60 3 check_cname_deleted || fail "DNS CNAME still exists after finalization"
+    pass "DNS CNAME deleted by finalizer"
+
+    kubectl delete cloudflaregatewayparameters recreate-params -n "$TEST_NS" --ignore-not-found
+    kubectl delete service recreate-backend -n "$TEST_NS" --ignore-not-found
+}
+
 test_multiple_listeners_rejected() {
     log "Creating Gateway 'multi-listen-gw' with two listeners..."
     kubectl apply -f - <<EOF
@@ -870,4 +1105,5 @@ run_tests \
     test_deployment_patches \
     test_disabled_reconciliation \
     test_dns_config_removal \
-    test_multiple_listeners_rejected
+    test_multiple_listeners_rejected \
+    test_cluster_recreation

--- a/internal/cloudflare/client.go
+++ b/internal/cloudflare/client.go
@@ -57,11 +57,12 @@ type PoolOrigin struct {
 
 // PoolConfig holds the configuration for a Cloudflare LB pool.
 type PoolConfig struct {
-	Name      string       // Pool name.
-	MonitorID string       // Associated monitor ID.
-	Origins   []PoolOrigin // Pool origins.
-	Weight    float64      // Pool-level weight for LB steering (0-1). Default: 1.
-	Enabled   bool         // Whether this pool is enabled.
+	Name        string       // Pool name.
+	Description string       // Pool description (ownership metadata).
+	MonitorID   string       // Associated monitor ID.
+	Origins     []PoolOrigin // Pool origins.
+	Weight      float64      // Pool-level weight for LB steering (0-1). Default: 1.
+	Enabled     bool         // Whether this pool is enabled.
 }
 
 // LoadBalancerPool represents a Cloudflare LB pool with its ID and name.
@@ -85,14 +86,14 @@ type Client interface {
 	// Zone/DNS operations.
 	ListZoneIDs(ctx context.Context) ([]string, error)
 	FindZoneIDByHostname(ctx context.Context, hostname string) (string, error)
-	EnsureDNSCNAME(ctx context.Context, zoneID, hostname, target string) error
+	EnsureDNSCNAME(ctx context.Context, zoneID, hostname, target, comment string) error
 	DeleteDNSCNAME(ctx context.Context, zoneID, hostname string) error
 	ListDNSCNAMEsByTarget(ctx context.Context, zoneID, target string) ([]string, error)
 
 	// Load Balancer Monitor operations (account-level).
-	CreateMonitor(ctx context.Context, name string, config MonitorConfig) (monitorID string, err error)
+	CreateMonitor(ctx context.Context, name, description string, config MonitorConfig) (monitorID string, err error)
 	GetMonitorByName(ctx context.Context, name string) (monitorID string, err error)
-	UpdateMonitor(ctx context.Context, monitorID, name string, config MonitorConfig) error
+	UpdateMonitor(ctx context.Context, monitorID, name, description string, config MonitorConfig) error
 	DeleteMonitor(ctx context.Context, monitorID string) error
 
 	// Load Balancer Pool operations (account-level).
@@ -103,7 +104,7 @@ type Client interface {
 	ListPoolsByPrefix(ctx context.Context, prefix string) ([]LoadBalancerPool, error)
 
 	// Load Balancer operations (zone-level).
-	EnsureLoadBalancer(ctx context.Context, zoneID, hostname string, poolIDs []string, steeringPolicy, sessionAffinity string, poolWeights map[string]float64) error
+	EnsureLoadBalancer(ctx context.Context, zoneID, hostname string, poolIDs []string, steeringPolicy, sessionAffinity, description string, poolWeights map[string]float64) error
 	DeleteLoadBalancer(ctx context.Context, zoneID, hostname string) error
 	ListLoadBalancerHostnames(ctx context.Context, zoneID string) ([]string, error)
 }
@@ -294,7 +295,7 @@ func (c *client) FindZoneIDByHostname(ctx context.Context, hostname string) (str
 	return "", fmt.Errorf("no zone found for hostname %q", hostname)
 }
 
-func (c *client) EnsureDNSCNAME(ctx context.Context, zoneID, hostname, target string) error {
+func (c *client) EnsureDNSCNAME(ctx context.Context, zoneID, hostname, target, comment string) error {
 	pager := c.client.DNS.Records.ListAutoPaging(ctx, dns.RecordListParams{
 		ZoneID: cloudflare.F(zoneID),
 		Name:   cloudflare.F(dns.RecordListParamsName{Exact: cloudflare.F(hostname)}),
@@ -314,6 +315,7 @@ func (c *client) EnsureDNSCNAME(ctx context.Context, zoneID, hostname, target st
 					Type:    cloudflare.F(dns.CNAMERecordTypeCNAME),
 					TTL:     cloudflare.F(dns.TTL1),
 					Proxied: cloudflare.F(true),
+					Comment: cloudflare.String(comment),
 				},
 			})
 			return err
@@ -330,6 +332,7 @@ func (c *client) EnsureDNSCNAME(ctx context.Context, zoneID, hostname, target st
 			Type:    cloudflare.F(dns.CNAMERecordTypeCNAME),
 			TTL:     cloudflare.F(dns.TTL1),
 			Proxied: cloudflare.F(true),
+			Comment: cloudflare.String(comment),
 		},
 	})
 	return err
@@ -374,10 +377,11 @@ func (c *client) ListDNSCNAMEsByTarget(ctx context.Context, zoneID, target strin
 
 // --- Load Balancer Monitor operations ---
 
-func (c *client) CreateMonitor(ctx context.Context, name string, config MonitorConfig) (string, error) {
+func (c *client) CreateMonitor(ctx context.Context, name, description string, config MonitorConfig) (string, error) {
+	desc := monitorDescription(name, description)
 	params := load_balancers.MonitorNewParams{
 		AccountID:     cloudflare.String(c.accountID),
-		Description:   cloudflare.String(name),
+		Description:   cloudflare.String(desc),
 		Type:          cloudflare.F(load_balancers.MonitorNewParamsType(config.Type)),
 		Path:          cloudflare.String(config.Path),
 		ExpectedCodes: cloudflare.String(config.ExpectedCodes),
@@ -396,6 +400,7 @@ func (c *client) CreateMonitor(ctx context.Context, name string, config MonitorC
 }
 
 func (c *client) GetMonitorByName(ctx context.Context, name string) (string, error) {
+	prefix := name + " | "
 	page, err := c.client.LoadBalancers.Monitors.List(ctx, load_balancers.MonitorListParams{
 		AccountID: cloudflare.String(c.accountID),
 	})
@@ -403,17 +408,18 @@ func (c *client) GetMonitorByName(ctx context.Context, name string) (string, err
 		return "", fmt.Errorf("listing monitors: %w", err)
 	}
 	for _, m := range page.Result {
-		if m.Description == name {
+		if strings.HasPrefix(m.Description, prefix) || m.Description == name {
 			return m.ID, nil
 		}
 	}
 	return "", nil
 }
 
-func (c *client) UpdateMonitor(ctx context.Context, monitorID, name string, config MonitorConfig) error {
+func (c *client) UpdateMonitor(ctx context.Context, monitorID, name, description string, config MonitorConfig) error {
+	desc := monitorDescription(name, description)
 	params := load_balancers.MonitorUpdateParams{
 		AccountID:     cloudflare.String(c.accountID),
-		Description:   cloudflare.String(name),
+		Description:   cloudflare.String(desc),
 		Type:          cloudflare.F(load_balancers.MonitorUpdateParamsType(config.Type)),
 		Path:          cloudflare.String(config.Path),
 		ExpectedCodes: cloudflare.String(config.ExpectedCodes),
@@ -429,6 +435,12 @@ func (c *client) UpdateMonitor(ctx context.Context, monitorID, name string, conf
 		return fmt.Errorf("updating monitor %q: %w", monitorID, err)
 	}
 	return nil
+}
+
+// monitorDescription builds the Description field for a monitor, encoding both
+// the hash name (used for lookup) and the ownership metadata.
+func monitorDescription(name, description string) string {
+	return name + " | " + description
 }
 
 func (c *client) DeleteMonitor(ctx context.Context, monitorID string) error {
@@ -457,11 +469,12 @@ func (c *client) CreatePool(ctx context.Context, config PoolConfig) (string, err
 		})
 	}
 	pool, err := c.client.LoadBalancers.Pools.New(ctx, load_balancers.PoolNewParams{
-		AccountID: cloudflare.String(c.accountID),
-		Name:      cloudflare.String(config.Name),
-		Origins:   cloudflare.F(origins),
-		Monitor:   cloudflare.String(config.MonitorID),
-		Enabled:   cloudflare.Bool(config.Enabled),
+		AccountID:   cloudflare.String(c.accountID),
+		Name:        cloudflare.String(config.Name),
+		Description: cloudflare.String(config.Description),
+		Origins:     cloudflare.F(origins),
+		Monitor:     cloudflare.String(config.MonitorID),
+		Enabled:     cloudflare.Bool(config.Enabled),
 	})
 	if err != nil {
 		return "", fmt.Errorf("creating pool %q: %w", config.Name, err)
@@ -509,11 +522,12 @@ func (c *client) UpdatePool(ctx context.Context, poolID string, config PoolConfi
 		})
 	}
 	_, err := c.client.LoadBalancers.Pools.Update(ctx, poolID, load_balancers.PoolUpdateParams{
-		AccountID: cloudflare.String(c.accountID),
-		Name:      cloudflare.String(config.Name),
-		Origins:   cloudflare.F(origins),
-		Monitor:   cloudflare.String(config.MonitorID),
-		Enabled:   cloudflare.Bool(config.Enabled),
+		AccountID:   cloudflare.String(c.accountID),
+		Name:        cloudflare.String(config.Name),
+		Description: cloudflare.String(config.Description),
+		Origins:     cloudflare.F(origins),
+		Monitor:     cloudflare.String(config.MonitorID),
+		Enabled:     cloudflare.Bool(config.Enabled),
 	})
 	if err != nil {
 		return fmt.Errorf("updating pool %q: %w", poolID, err)
@@ -552,7 +566,7 @@ func (c *client) ListPoolsByPrefix(ctx context.Context, prefix string) ([]LoadBa
 
 // --- Load Balancer operations ---
 
-func (c *client) EnsureLoadBalancer(ctx context.Context, zoneID, hostname string, poolIDs []string, steeringPolicy, sessionAffinity string, poolWeights map[string]float64) error {
+func (c *client) EnsureLoadBalancer(ctx context.Context, zoneID, hostname string, poolIDs []string, steeringPolicy, sessionAffinity, description string, poolWeights map[string]float64) error {
 	// List existing LBs to find one matching the hostname.
 	page, err := c.client.LoadBalancers.List(ctx, load_balancers.LoadBalancerListParams{
 		ZoneID: cloudflare.String(zoneID),
@@ -581,6 +595,7 @@ func (c *client) EnsureLoadBalancer(ctx context.Context, zoneID, hostname string
 		params := load_balancers.LoadBalancerUpdateParams{
 			ZoneID:          cloudflare.String(zoneID),
 			Name:            cloudflare.String(hostname),
+			Description:     cloudflare.String(description),
 			DefaultPools:    cloudflare.F(defaultPools),
 			FallbackPool:    cloudflare.String(poolIDs[0]),
 			Proxied:         cloudflare.Bool(true),
@@ -601,6 +616,7 @@ func (c *client) EnsureLoadBalancer(ctx context.Context, zoneID, hostname string
 	params := load_balancers.LoadBalancerNewParams{
 		ZoneID:          cloudflare.String(zoneID),
 		Name:            cloudflare.String(hostname),
+		Description:     cloudflare.String(description),
 		DefaultPools:    cloudflare.F(defaultPools),
 		FallbackPool:    cloudflare.String(poolIDs[0]),
 		Proxied:         cloudflare.Bool(true),

--- a/internal/cloudflare/client_test.go
+++ b/internal/cloudflare/client_test.go
@@ -626,7 +626,7 @@ func TestEnsureDNSCNAME(t *testing.T) {
 		})
 		c := newTestClient(t, mux)
 
-		g.Expect(c.EnsureDNSCNAME(context.Background(), "zone-1", "app.example.com", "tunnel.cfargotunnel.com")).To(Succeed())
+		g.Expect(c.EnsureDNSCNAME(context.Background(), "zone-1", "app.example.com", "tunnel.cfargotunnel.com", "test comment")).To(Succeed())
 		g.Expect(createdBody["name"]).To(Equal("app.example.com"))
 		g.Expect(createdBody["content"]).To(Equal("tunnel.cfargotunnel.com"))
 	})
@@ -657,7 +657,7 @@ func TestEnsureDNSCNAME(t *testing.T) {
 		})
 		c := newTestClient(t, mux)
 
-		g.Expect(c.EnsureDNSCNAME(context.Background(), "zone-1", "app.example.com", "new-target.cfargotunnel.com")).To(Succeed())
+		g.Expect(c.EnsureDNSCNAME(context.Background(), "zone-1", "app.example.com", "new-target.cfargotunnel.com", "test comment")).To(Succeed())
 		g.Expect(updatedBody["content"]).To(Equal("new-target.cfargotunnel.com"))
 	})
 
@@ -669,7 +669,7 @@ func TestEnsureDNSCNAME(t *testing.T) {
 		})
 		c := newTestClient(t, mux)
 
-		g.Expect(c.EnsureDNSCNAME(context.Background(), "zone-1", "app.example.com", "tunnel.cfargotunnel.com")).To(HaveOccurred())
+		g.Expect(c.EnsureDNSCNAME(context.Background(), "zone-1", "app.example.com", "tunnel.cfargotunnel.com", "test comment")).To(HaveOccurred())
 	})
 
 	t.Run("update error", func(t *testing.T) {
@@ -690,7 +690,7 @@ func TestEnsureDNSCNAME(t *testing.T) {
 		})
 		c := newTestClient(t, mux)
 
-		g.Expect(c.EnsureDNSCNAME(context.Background(), "zone-1", "app.example.com", "new-target.cfargotunnel.com")).To(HaveOccurred())
+		g.Expect(c.EnsureDNSCNAME(context.Background(), "zone-1", "app.example.com", "new-target.cfargotunnel.com", "test comment")).To(HaveOccurred())
 	})
 
 	t.Run("create error", func(t *testing.T) {
@@ -704,7 +704,7 @@ func TestEnsureDNSCNAME(t *testing.T) {
 		})
 		c := newTestClient(t, mux)
 
-		g.Expect(c.EnsureDNSCNAME(context.Background(), "zone-1", "app.example.com", "tunnel.cfargotunnel.com")).To(HaveOccurred())
+		g.Expect(c.EnsureDNSCNAME(context.Background(), "zone-1", "app.example.com", "tunnel.cfargotunnel.com", "test comment")).To(HaveOccurred())
 	})
 
 	t.Run("no-op when target matches", func(t *testing.T) {
@@ -730,7 +730,7 @@ func TestEnsureDNSCNAME(t *testing.T) {
 		})
 		c := newTestClient(t, mux)
 
-		g.Expect(c.EnsureDNSCNAME(context.Background(), "zone-1", "app.example.com", "tunnel.cfargotunnel.com")).To(Succeed())
+		g.Expect(c.EnsureDNSCNAME(context.Background(), "zone-1", "app.example.com", "tunnel.cfargotunnel.com", "test comment")).To(Succeed())
 		g.Expect(updateCalled).To(BeFalse())
 		g.Expect(createCalled).To(BeFalse())
 	})
@@ -875,17 +875,17 @@ func TestCreateMonitor(t *testing.T) {
 			body, _ := io.ReadAll(r.Body)
 			var params map[string]any
 			g.Expect(json.Unmarshal(body, &params)).To(Succeed())
-			g.Expect(params["description"]).To(Equal("gateway-uid-1"))
+			g.Expect(params["description"]).To(Equal("gateway-uid-1 | test description"))
 			g.Expect(params["type"]).To(Equal("https"))
 			g.Expect(params["path"]).To(Equal("/ready"))
 			writeJSON(w, http.StatusOK, envelope(map[string]any{
 				"id":          "mon-123",
-				"description": "gateway-uid-1",
+				"description": "gateway-uid-1 | test description",
 			}))
 		})
 		c := newTestClient(t, mux)
 
-		id, err := c.CreateMonitor(context.Background(), "gateway-uid-1", cloudflare.MonitorConfig{
+		id, err := c.CreateMonitor(context.Background(), "gateway-uid-1", "test description", cloudflare.MonitorConfig{
 			Type: "https", Path: "/ready", Interval: 60, Timeout: 5, ExpectedCodes: "200",
 		})
 		g.Expect(err).NotTo(HaveOccurred())
@@ -900,7 +900,7 @@ func TestCreateMonitor(t *testing.T) {
 		})
 		c := newTestClient(t, mux)
 
-		_, err := c.CreateMonitor(context.Background(), "gateway-uid-1", cloudflare.MonitorConfig{})
+		_, err := c.CreateMonitor(context.Background(), "gateway-uid-1", "test description", cloudflare.MonitorConfig{})
 		g.Expect(err).To(HaveOccurred())
 	})
 }
@@ -957,7 +957,7 @@ func TestUpdateMonitor(t *testing.T) {
 		})
 		c := newTestClient(t, mux)
 
-		err := c.UpdateMonitor(context.Background(), "mon-123", "gateway-uid-1", cloudflare.MonitorConfig{
+		err := c.UpdateMonitor(context.Background(), "mon-123", "gateway-uid-1", "test description", cloudflare.MonitorConfig{
 			Type: "https", Path: "/ready", Interval: 60, Timeout: 5, ExpectedCodes: "200",
 		})
 		g.Expect(err).NotTo(HaveOccurred())
@@ -971,7 +971,7 @@ func TestUpdateMonitor(t *testing.T) {
 		})
 		c := newTestClient(t, mux)
 
-		err := c.UpdateMonitor(context.Background(), "mon-123", "name", cloudflare.MonitorConfig{})
+		err := c.UpdateMonitor(context.Background(), "mon-123", "name", "test description", cloudflare.MonitorConfig{})
 		g.Expect(err).To(HaveOccurred())
 	})
 }
@@ -1257,7 +1257,7 @@ func TestEnsureLoadBalancer(t *testing.T) {
 		c := newTestClient(t, mux)
 
 		err := c.EnsureLoadBalancer(context.Background(), "zone-1", "app.example.com",
-			[]string{"pool-1", "pool-2"}, "geo", "none", nil)
+			[]string{"pool-1", "pool-2"}, "geo", "none", "test desc", nil)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(createCalled).To(BeTrue())
 	})
@@ -1283,7 +1283,7 @@ func TestEnsureLoadBalancer(t *testing.T) {
 		c := newTestClient(t, mux)
 
 		err := c.EnsureLoadBalancer(context.Background(), "zone-1", "app.example.com",
-			[]string{"pool-1"}, "geo", "none", nil)
+			[]string{"pool-1"}, "geo", "none", "test desc", nil)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(updateCalled).To(BeTrue())
 	})
@@ -1297,7 +1297,7 @@ func TestEnsureLoadBalancer(t *testing.T) {
 		c := newTestClient(t, mux)
 
 		err := c.EnsureLoadBalancer(context.Background(), "zone-1", "app.example.com",
-			[]string{"pool-1"}, "geo", "none", nil)
+			[]string{"pool-1"}, "geo", "none", "test desc", nil)
 		g.Expect(err).To(HaveOccurred())
 	})
 
@@ -1315,7 +1315,7 @@ func TestEnsureLoadBalancer(t *testing.T) {
 		c := newTestClient(t, mux)
 
 		err := c.EnsureLoadBalancer(context.Background(), "zone-1", "app.example.com",
-			[]string{"pool-1"}, "geo", "none", nil)
+			[]string{"pool-1"}, "geo", "none", "test desc", nil)
 		g.Expect(err).To(HaveOccurred())
 	})
 
@@ -1331,7 +1331,7 @@ func TestEnsureLoadBalancer(t *testing.T) {
 		c := newTestClient(t, mux)
 
 		err := c.EnsureLoadBalancer(context.Background(), "zone-1", "app.example.com",
-			[]string{"pool-1"}, "geo", "none", nil)
+			[]string{"pool-1"}, "geo", "none", "test desc", nil)
 		g.Expect(err).To(HaveOccurred())
 	})
 
@@ -1358,7 +1358,7 @@ func TestEnsureLoadBalancer(t *testing.T) {
 		c := newTestClient(t, mux)
 
 		err := c.EnsureLoadBalancer(context.Background(), "zone-1", "app.example.com",
-			[]string{"pool-1", "pool-2"}, "random", "none",
+			[]string{"pool-1", "pool-2"}, "random", "none", "test desc",
 			map[string]float64{"pool-1": 0.7, "pool-2": 0.3})
 		g.Expect(err).NotTo(HaveOccurred())
 	})
@@ -1384,7 +1384,7 @@ func TestEnsureLoadBalancer(t *testing.T) {
 		c := newTestClient(t, mux)
 
 		err := c.EnsureLoadBalancer(context.Background(), "zone-1", "app.example.com",
-			[]string{"pool-1", "pool-2"}, "random", "none",
+			[]string{"pool-1", "pool-2"}, "random", "none", "test desc",
 			map[string]float64{"pool-1": 0.9, "pool-2": 0.1})
 		g.Expect(err).NotTo(HaveOccurred())
 	})

--- a/internal/cloudflare/retry.go
+++ b/internal/cloudflare/retry.go
@@ -179,9 +179,9 @@ func (r *retryClient) FindZoneIDByHostname(ctx context.Context, hostname string)
 	})
 }
 
-func (r *retryClient) EnsureDNSCNAME(ctx context.Context, zoneID, hostname, target string) error {
+func (r *retryClient) EnsureDNSCNAME(ctx context.Context, zoneID, hostname, target, comment string) error {
 	return retry0(ctx, r.maxRetries, func() error {
-		return r.inner.EnsureDNSCNAME(ctx, zoneID, hostname, target)
+		return r.inner.EnsureDNSCNAME(ctx, zoneID, hostname, target, comment)
 	})
 }
 
@@ -199,9 +199,9 @@ func (r *retryClient) ListDNSCNAMEsByTarget(ctx context.Context, zoneID, target 
 
 // --- Load Balancer Monitor operations ---
 
-func (r *retryClient) CreateMonitor(ctx context.Context, name string, config MonitorConfig) (string, error) {
+func (r *retryClient) CreateMonitor(ctx context.Context, name, description string, config MonitorConfig) (string, error) {
 	return retry1(ctx, r.maxRetries, func() (string, error) {
-		return r.inner.CreateMonitor(ctx, name, config)
+		return r.inner.CreateMonitor(ctx, name, description, config)
 	})
 }
 
@@ -211,9 +211,9 @@ func (r *retryClient) GetMonitorByName(ctx context.Context, name string) (string
 	})
 }
 
-func (r *retryClient) UpdateMonitor(ctx context.Context, monitorID, name string, config MonitorConfig) error {
+func (r *retryClient) UpdateMonitor(ctx context.Context, monitorID, name, description string, config MonitorConfig) error {
 	return retry0(ctx, r.maxRetries, func() error {
-		return r.inner.UpdateMonitor(ctx, monitorID, name, config)
+		return r.inner.UpdateMonitor(ctx, monitorID, name, description, config)
 	})
 }
 
@@ -257,9 +257,9 @@ func (r *retryClient) ListPoolsByPrefix(ctx context.Context, prefix string) ([]L
 
 // --- Load Balancer operations ---
 
-func (r *retryClient) EnsureLoadBalancer(ctx context.Context, zoneID, hostname string, poolIDs []string, steeringPolicy, sessionAffinity string, poolWeights map[string]float64) error {
+func (r *retryClient) EnsureLoadBalancer(ctx context.Context, zoneID, hostname string, poolIDs []string, steeringPolicy, sessionAffinity, description string, poolWeights map[string]float64) error {
 	return retry0(ctx, r.maxRetries, func() error {
-		return r.inner.EnsureLoadBalancer(ctx, zoneID, hostname, poolIDs, steeringPolicy, sessionAffinity, poolWeights)
+		return r.inner.EnsureLoadBalancer(ctx, zoneID, hostname, poolIDs, steeringPolicy, sessionAffinity, description, poolWeights)
 	})
 }
 

--- a/internal/cloudflare/retry_test.go
+++ b/internal/cloudflare/retry_test.go
@@ -254,7 +254,7 @@ func TestWithRetry_DelegatesAllMethods(t *testing.T) {
 	g.Expect(zoneID).To(Equal("zone-1"))
 	g.Expect(inner.calls["FindZoneIDByHostname"]).To(Equal(1))
 
-	err = c.EnsureDNSCNAME(ctx, "zone-1", "app.example.com", "target.example.com")
+	err = c.EnsureDNSCNAME(ctx, "zone-1", "app.example.com", "target.example.com", "test comment")
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(inner.calls["EnsureDNSCNAME"]).To(Equal(1))
 
@@ -268,7 +268,7 @@ func TestWithRetry_DelegatesAllMethods(t *testing.T) {
 	g.Expect(inner.calls["ListDNSCNAMEsByTarget"]).To(Equal(1))
 
 	// Monitor operations.
-	monitorID, err := c.CreateMonitor(ctx, "my-monitor", cloudflare.MonitorConfig{Type: "https"})
+	monitorID, err := c.CreateMonitor(ctx, "my-monitor", "test desc", cloudflare.MonitorConfig{Type: "https"})
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(monitorID).To(Equal("monitor-id"))
 	g.Expect(inner.calls["CreateMonitor"]).To(Equal(1))
@@ -278,7 +278,7 @@ func TestWithRetry_DelegatesAllMethods(t *testing.T) {
 	g.Expect(monitorID).To(Equal("monitor-id"))
 	g.Expect(inner.calls["GetMonitorByName"]).To(Equal(1))
 
-	err = c.UpdateMonitor(ctx, "monitor-id", "my-monitor", cloudflare.MonitorConfig{Type: "https"})
+	err = c.UpdateMonitor(ctx, "monitor-id", "my-monitor", "test desc", cloudflare.MonitorConfig{Type: "https"})
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(inner.calls["UpdateMonitor"]).To(Equal(1))
 
@@ -312,7 +312,7 @@ func TestWithRetry_DelegatesAllMethods(t *testing.T) {
 	g.Expect(inner.calls["ListPoolsByPrefix"]).To(Equal(1))
 
 	// Load Balancer operations.
-	err = c.EnsureLoadBalancer(ctx, "zone-1", "app.example.com", []string{"pool-1"}, "random", "none", map[string]float64{"pool-1": 1.0})
+	err = c.EnsureLoadBalancer(ctx, "zone-1", "app.example.com", []string{"pool-1"}, "random", "none", "test desc", map[string]float64{"pool-1": 1.0})
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(inner.calls["EnsureLoadBalancer"]).To(Equal(1))
 
@@ -397,7 +397,7 @@ func (m *mockRetryClient) FindZoneIDByHostname(_ context.Context, _ string) (str
 	return "zone-1", nil
 }
 
-func (m *mockRetryClient) EnsureDNSCNAME(_ context.Context, _, _, _ string) error {
+func (m *mockRetryClient) EnsureDNSCNAME(_ context.Context, _, _, _, _ string) error {
 	m.calls["EnsureDNSCNAME"]++
 	return nil
 }
@@ -412,7 +412,7 @@ func (m *mockRetryClient) ListDNSCNAMEsByTarget(_ context.Context, _, _ string) 
 	return []string{"app.example.com"}, nil
 }
 
-func (m *mockRetryClient) CreateMonitor(_ context.Context, _ string, _ cloudflare.MonitorConfig) (string, error) {
+func (m *mockRetryClient) CreateMonitor(_ context.Context, _, _ string, _ cloudflare.MonitorConfig) (string, error) {
 	m.calls["CreateMonitor"]++
 	return "monitor-id", nil
 }
@@ -422,7 +422,7 @@ func (m *mockRetryClient) GetMonitorByName(_ context.Context, _ string) (string,
 	return "monitor-id", nil
 }
 
-func (m *mockRetryClient) UpdateMonitor(_ context.Context, _, _ string, _ cloudflare.MonitorConfig) error {
+func (m *mockRetryClient) UpdateMonitor(_ context.Context, _, _, _ string, _ cloudflare.MonitorConfig) error {
 	m.calls["UpdateMonitor"]++
 	return nil
 }
@@ -460,7 +460,7 @@ func (m *mockRetryClient) ListPoolsByPrefix(_ context.Context, _ string) ([]clou
 	return []cloudflare.LoadBalancerPool{{ID: "p1", Name: "pool-1"}}, nil
 }
 
-func (m *mockRetryClient) EnsureLoadBalancer(_ context.Context, _, _ string, _ []string, _, _ string, _ map[string]float64) error {
+func (m *mockRetryClient) EnsureLoadBalancer(_ context.Context, _, _ string, _ []string, _, _, _ string, _ map[string]float64) error {
 	m.calls["EnsureLoadBalancer"]++
 	return nil
 }

--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -103,12 +103,13 @@ const (
 
 // tunnelEntry represents one desired tunnel and its associated Kubernetes resources.
 type tunnelEntry struct {
-	tunnelName     string // Cloudflare tunnel name (globally unique via Gateway UID)
-	deploymentName string // cloudflared Deployment name
-	secretName     string // tunnel token Secret name
-	azName         string // AZ name ("" if no AZ)
-	serviceName    string // Service name ("" if not per-backendRef)
-	tunnelID       string // filled after ensureTunnels
+	tunnelName       string // Cloudflare tunnel name (deterministic hash)
+	deploymentName   string // cloudflared Deployment name
+	secretName       string // tunnel token Secret name
+	azName           string // AZ name ("" if no AZ)
+	serviceNamespace string // Service namespace ("" if not per-backendRef)
+	serviceName      string // Service name ("" if not per-backendRef)
+	tunnelID         string // filled after ensureTunnels
 }
 
 // +kubebuilder:rbac:groups=cloudflare-gateway-controller.io,resources=cloudflaregatewayparameters,verbs=get;list;watch
@@ -319,8 +320,15 @@ func (r *GatewayReconciler) reconcile(ctx context.Context, gw *gatewayv1.Gateway
 	}
 	changes = append(changes, deployChanges...)
 
+	// Read existing CGS for previous state (needed for stale cleanup of tunnels,
+	// pools, and zone changes).
+	cgs, cgsErr := r.getCGS(ctx, gw)
+	if cgsErr != nil {
+		return r.reconcileError(ctx, gw, fmt.Errorf("getting CloudflareGatewayStatus: %w", cgsErr))
+	}
+
 	// Clean up stale tunnel resources (from removed AZs, services, or mode switches).
-	cleanupChanges, cleanupErrs := r.cleanupStaleTunnelResources(ctx, tc, gw, entries)
+	cleanupChanges, cleanupErrs := r.cleanupStaleTunnelResources(ctx, tc, gw, entries, cgsTunnels(cgs))
 	changes = append(changes, cleanupChanges...)
 	errs = append(errs, cleanupErrs...)
 
@@ -333,12 +341,6 @@ func (r *GatewayReconciler) reconcile(ctx context.Context, gw *gatewayv1.Gateway
 		return r.reconcileError(ctx, gw, err)
 	}
 	changes = append(changes, configChanges...)
-
-	// Read existing CGS for previous zone info (needed for cleanup on mode/zone changes).
-	cgs, cgsErr := r.getCGS(ctx, gw)
-	if cgsErr != nil {
-		return r.reconcileError(ctx, gw, fmt.Errorf("getting CloudflareGatewayStatus: %w", cgsErr))
-	}
 
 	// Reconcile DNS or Load Balancer depending on mode, handling zone changes.
 	var zoneName string
@@ -410,25 +412,26 @@ func (r *GatewayReconciler) reconcileDNSOrLB(
 		if len(entries) > 0 {
 			tunnelID = entries[0].tunnelID
 		}
-		dnsChanges, dnsErr := r.reconcileDNS(ctx, tc, tunnelID, zoneName, validRoutes)
+		dnsChanges, dnsErr := r.reconcileDNS(ctx, tc, gw, tunnelID, zoneName, validRoutes)
 		res.changes = append(res.changes, dnsChanges...)
 		res.dnsErr = dnsErr
 		if dnsErr != nil {
 			res.errs = append(res.errs, *dnsErr)
 		}
 		// Clean up stale LB resources if switching FROM LB mode.
-		// Use CGS zone info (from previous reconciliation) since the current
-		// params may reference a different zone or no zone at all.
-		cleanupZoneName := cgsZoneName
-		cleanupZoneID := cgsZoneID
-		if cleanupZoneName == "" && zoneName != "" {
-			// Fallback to current params if CGS has no zone info (first reconcile
-			// or CGS not yet populated).
-			cleanupZoneName = zoneName
+		// Only attempt cleanup if CGS indicates the gateway was in LB mode.
+		if cgs != nil && cgs.Status.LoadBalancer != nil {
+			cleanupZoneName := cgsZoneName
+			cleanupZoneID := cgsZoneID
+			if cleanupZoneName == "" && zoneName != "" {
+				// Fallback to current params if CGS has no zone info (first reconcile
+				// or CGS not yet populated).
+				cleanupZoneName = zoneName
+			}
+			lbCleanupChanges, lbCleanupErrs := r.cleanupAllLBResources(ctx, tc, gw, cleanupZoneName, cleanupZoneID, cgs.Status.LoadBalancer.Hostnames, cgs.Status.LoadBalancer.Pools)
+			res.changes = append(res.changes, lbCleanupChanges...)
+			res.errs = append(res.errs, lbCleanupErrs...)
 		}
-		lbCleanupChanges, lbCleanupErrs := r.cleanupAllLBResources(ctx, tc, gw, cleanupZoneName, cleanupZoneID)
-		res.changes = append(res.changes, lbCleanupChanges...)
-		res.errs = append(res.errs, lbCleanupErrs...)
 	} else {
 		// If zone changed, clean up LB resources in the old zone before
 		// reconciling in the new zone.
@@ -442,13 +445,13 @@ func (r *GatewayReconciler) reconcileDNSOrLB(
 				}
 			}
 			if oldZoneID != "" {
-				oldLBChanges, oldLBErrs := r.cleanupAllLBResources(ctx, tc, gw, cgsZoneName, oldZoneID)
+				oldLBChanges, oldLBErrs := r.cleanupAllLBResources(ctx, tc, gw, cgsZoneName, oldZoneID, cgsLBHostnames(cgs), cgsLBPools(cgs))
 				res.changes = append(res.changes, oldLBChanges...)
 				res.errs = append(res.errs, oldLBErrs...)
 			}
 		}
 		var lbChanges, lbErrs []string
-		res.lbState, lbChanges, lbErrs = r.reconcileLoadBalancer(ctx, tc, gw, params, mode, entries, validRoutes)
+		res.lbState, lbChanges, lbErrs = r.reconcileLoadBalancer(ctx, tc, gw, params, mode, entries, validRoutes, cgsLBHostnames(cgs), cgsLBPools(cgs))
 		res.changes = append(res.changes, lbChanges...)
 		res.errs = append(res.errs, lbErrs...)
 		// Clean up stale DNS if switching FROM simple mode.
@@ -879,22 +882,16 @@ func (r *GatewayReconciler) finalizeEnabled(ctx context.Context, gw *gatewayv1.G
 				return changes, fmt.Errorf("finding zone ID for LB cleanup: %w", err)
 			}
 		}
-		lbCleanupChanges, lbCleanupErrs := r.cleanupAllLBResources(ctx, tc, gw, cleanupZoneName, cleanupZoneID)
+		lbCleanupChanges, lbCleanupErrs := r.cleanupAllLBResources(ctx, tc, gw, cleanupZoneName, cleanupZoneID, cgs.Status.LoadBalancer.Hostnames, cgs.Status.LoadBalancer.Pools)
 		changes = append(changes, lbCleanupChanges...)
 		if len(lbCleanupErrs) > 0 {
 			return changes, fmt.Errorf("cleaning up LB resources: %s", strings.Join(lbCleanupErrs, "; "))
 		}
 	}
 
-	// Delete all tunnels owned by this Gateway (matching "gateway-{UID}" prefix).
-	prefix := "gateway-" + string(gw.UID)
-	tunnels, err := tc.ListTunnels(ctx)
-	if err != nil {
-		return changes, fmt.Errorf("listing tunnels for deletion: %w", err)
-	}
-
-	for _, t := range tunnels {
-		if !strings.HasPrefix(t.Name, prefix) {
+	// Delete all tunnels owned by this Gateway using CGS-tracked tunnel state.
+	for _, t := range cgsTunnels(cgs) {
+		if t.ID == "" {
 			continue
 		}
 

--- a/internal/controller/gateway_controller_lb_test.go
+++ b/internal/controller/gateway_controller_lb_test.go
@@ -299,8 +299,8 @@ func TestGatewayReconciler_TrafficSplitting(t *testing.T) {
 	g.Expect(testMock.monitors).To(HaveKey(monitorName))
 
 	// Verify pools were created (one per service) for this Gateway.
-	g.Expect(testMock.poolsByName).To(HaveKey(apiv1.PoolNameForService(&gwResult, "svc-a")))
-	g.Expect(testMock.poolsByName).To(HaveKey(apiv1.PoolNameForService(&gwResult, "svc-b")))
+	g.Expect(testMock.poolsByName).To(HaveKey(apiv1.PoolNameForService(&gwResult, gwResult.Namespace, "svc-a")))
+	g.Expect(testMock.poolsByName).To(HaveKey(apiv1.PoolNameForService(&gwResult, gwResult.Namespace, "svc-b")))
 
 	// Find the EnsureLoadBalancer call for our hostname.
 	var lbCall mockEnsureLBCall
@@ -387,6 +387,42 @@ func TestGatewayReconciler_LBDeletion(t *testing.T) {
 		g.Expect(programmed.Status).To(Equal(metav1.ConditionTrue))
 	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
 
+	// Create an HTTPRoute so CGS tracks the LB hostname for cleanup.
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route-lb-del",
+			Namespace: ns.Name,
+		},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Name: gatewayv1.ObjectName(gw.Name)},
+				},
+			},
+			Hostnames: []gatewayv1.Hostname{"del.example.com"},
+			Rules: []gatewayv1.HTTPRouteRule{{
+				BackendRefs: []gatewayv1.HTTPBackendRef{{
+					BackendRef: gatewayv1.BackendRef{
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Name: "my-service", Port: new(gatewayv1.PortNumber(8080)),
+						},
+					},
+				}},
+			}},
+		},
+	}
+	g.Expect(testClient.Create(testCtx, route)).To(Succeed())
+
+	// Wait for EnsureLoadBalancer to confirm CGS tracks the hostname.
+	g.Eventually(func() bool {
+		for _, c := range testMock.ensureLBCalls {
+			if c.Hostname == "del.example.com" {
+				return true
+			}
+		}
+		return false
+	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(BeTrue())
+
 	// Look up the Gateway to get UID for asserting on monitor/pool names.
 	var gwResult gatewayv1.Gateway
 	g.Expect(testClient.Get(testCtx, gwKey, &gwResult)).To(Succeed())
@@ -395,9 +431,6 @@ func TestGatewayReconciler_LBDeletion(t *testing.T) {
 	monitorName := apiv1.MonitorName(&gwResult)
 	g.Expect(testMock.monitors).To(HaveKey(monitorName))
 	g.Expect(testMock.poolsByName).To(HaveKey(apiv1.PoolNameForAZ(&gwResult, "az1")))
-
-	// Set up mock to return existing LB hostnames and pools for cleanup.
-	testMock.lbHostnames = []string{"del.example.com"}
 
 	// Delete the Gateway.
 	g.Eventually(func(g Gomega) {
@@ -475,7 +508,6 @@ func TestGatewayReconciler_LBStaleLBCleanup(t *testing.T) {
 	}
 	g.Expect(testClient.Create(testCtx, gw)).To(Succeed())
 	t.Cleanup(func() {
-		testMock.lbHostnames = nil
 		var latest gatewayv1.Gateway
 		if err := testClient.Get(testCtx, client.ObjectKeyFromObject(gw), &latest); err == nil {
 			_ = testClient.Delete(testCtx, &latest)
@@ -492,11 +524,8 @@ func TestGatewayReconciler_LBStaleLBCleanup(t *testing.T) {
 		g.Expect(programmed.Status).To(Equal(metav1.ConditionTrue))
 	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
 
-	// Simulate a stale LB hostname (no route references it).
-	testMock.lbHostnames = []string{"stale.example.com"}
-	testMock.deleteLBCalls = nil
-
-	// Create a route for a DIFFERENT hostname to trigger re-reconcile.
+	// Create a route for the hostname that will become stale. This causes
+	// CGS to track "stale.example.com" in LoadBalancer.Hostnames.
 	route := &gatewayv1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-route-lb-stale",
@@ -508,7 +537,7 @@ func TestGatewayReconciler_LBStaleLBCleanup(t *testing.T) {
 					{Name: gatewayv1.ObjectName(gw.Name)},
 				},
 			},
-			Hostnames: []gatewayv1.Hostname{"active.example.com"},
+			Hostnames: []gatewayv1.Hostname{"stale.example.com"},
 			Rules: []gatewayv1.HTTPRouteRule{{
 				BackendRefs: []gatewayv1.HTTPBackendRef{{
 					BackendRef: gatewayv1.BackendRef{
@@ -521,12 +550,24 @@ func TestGatewayReconciler_LBStaleLBCleanup(t *testing.T) {
 		},
 	}
 	g.Expect(testClient.Create(testCtx, route)).To(Succeed())
-	t.Cleanup(func() {
-		var latest gatewayv1.HTTPRoute
-		if err := testClient.Get(testCtx, client.ObjectKeyFromObject(route), &latest); err == nil {
-			_ = testClient.Delete(testCtx, &latest)
+
+	// Wait for EnsureLoadBalancer to confirm CGS tracks the hostname.
+	g.Eventually(func() bool {
+		for _, c := range testMock.ensureLBCalls {
+			if c.Hostname == "stale.example.com" {
+				return true
+			}
 		}
-	})
+		return false
+	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(BeTrue())
+
+	// Clear deleteLBCalls to track only subsequent deletions.
+	testMock.deleteLBCalls = nil
+
+	// Delete the route to make "stale.example.com" no longer desired.
+	// The next reconciliation will see it in CGS previousHostnames but not
+	// in the desired set, and delete it.
+	g.Expect(testClient.Delete(testCtx, route)).To(Succeed())
 
 	// Verify the stale LB hostname is deleted.
 	g.Eventually(func() bool {

--- a/internal/controller/gateway_controller_test.go
+++ b/internal/controller/gateway_controller_test.go
@@ -2792,8 +2792,9 @@ func TestGatewayReconciler_CloudflareTunnelLookupErrorDuringFinalization(t *test
 	waitForGatewayProgrammed(g, gw)
 	gwKey := client.ObjectKeyFromObject(gw)
 
-	// Set listTunnels error (will hit during finalization).
-	testMock.listTunnelsErr = fmt.Errorf("tunnel listing failed")
+	// Set deleteTunnel error (will hit during finalization when deleting
+	// CGS-tracked tunnels).
+	testMock.deleteTunnelErr = fmt.Errorf("tunnel deletion failed")
 
 	// Delete the Gateway.
 	g.Eventually(func(g Gomega) {
@@ -2810,7 +2811,7 @@ func TestGatewayReconciler_CloudflareTunnelLookupErrorDuringFinalization(t *test
 		g.Expect(ready).NotTo(BeNil())
 		g.Expect(ready.Status).To(Equal(metav1.ConditionUnknown))
 		g.Expect(ready.Reason).To(Equal(apiv1.ReasonProgressingWithRetry))
-		g.Expect(ready.Message).To(ContainSubstring("listing tunnels for deletion"))
+		g.Expect(ready.Message).To(ContainSubstring("deleting tunnel"))
 	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
 
 	// Verify Warning/ProgressingWithRetry/Finalize event.
@@ -2818,11 +2819,11 @@ func TestGatewayReconciler_CloudflareTunnelLookupErrorDuringFinalization(t *test
 		e := findEvent(g, ns.Name, gw.Name, corev1.EventTypeWarning, apiv1.ReasonProgressingWithRetry, apiv1.EventActionFinalize, "")
 		g.Expect(e).NotTo(BeNil())
 		g.Expect(e.Note).To(ContainSubstring("Finalization failed"))
-		g.Expect(e.Note).To(ContainSubstring("listing tunnels for deletion"))
+		g.Expect(e.Note).To(ContainSubstring("deleting tunnel"))
 	}).WithTimeout(5 * time.Second).WithPolling(200 * time.Millisecond).Should(Succeed())
 
 	// Clear error so cleanup (resetMockErrors) doesn't leave a stuck Gateway.
-	testMock.listTunnelsErr = nil
+	testMock.deleteTunnelErr = nil
 }
 
 func TestGatewayReconciler_DNSZoneChange(t *testing.T) {

--- a/internal/controller/gateway_dns.go
+++ b/internal/controller/gateway_dns.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	apiv1 "github.com/matheuscscp/cloudflare-gateway-controller/api/v1"
 	"github.com/matheuscscp/cloudflare-gateway-controller/internal/cloudflare"
 )
 
@@ -19,7 +20,7 @@ import (
 // account zones are deleted. Returns a non-nil *string on failure (using
 // new(fmt.Sprintf(...)) to allocate the error message inline), which is
 // reported on each HTTPRoute's DNSRecordsApplied condition.
-func (r *GatewayReconciler) reconcileDNS(ctx context.Context, tc cloudflare.Client, tunnelID, zoneName string, routes []*gatewayv1.HTTPRoute) ([]string, *string) {
+func (r *GatewayReconciler) reconcileDNS(ctx context.Context, tc cloudflare.Client, gw *gatewayv1.Gateway, tunnelID, zoneName string, routes []*gatewayv1.HTTPRoute) ([]string, *string) {
 	l := log.FromContext(ctx)
 
 	if zoneName == "" {
@@ -58,10 +59,11 @@ func (r *GatewayReconciler) reconcileDNS(ctx context.Context, tc cloudflare.Clie
 	}
 
 	// Create missing records.
+	dnsComment := apiv1.ResourceDescription(gw)
 	var dnsChanges []string
 	for h := range desired {
 		if _, ok := actualSet[h]; !ok {
-			if err := tc.EnsureDNSCNAME(ctx, zoneID, h, tunnelTarget); err != nil {
+			if err := tc.EnsureDNSCNAME(ctx, zoneID, h, tunnelTarget, dnsComment); err != nil {
 				return dnsChanges, new(fmt.Sprintf("Failed to ensure DNS CNAME for %q: %v", h, err))
 			}
 			dnsChanges = append(dnsChanges, fmt.Sprintf("created DNS CNAME for %s", h))

--- a/internal/controller/gateway_helpers.go
+++ b/internal/controller/gateway_helpers.go
@@ -186,19 +186,21 @@ func computeDesiredTunnels(gw *gatewayv1.Gateway, mode lbMode, params *apiv1.Clo
 			if hasAZs {
 				for _, az := range params.Spec.Tunnels.AvailabilityZones {
 					entries = append(entries, tunnelEntry{
-						tunnelName:     apiv1.TunnelNameForServiceAZ(gw, svc, az.Name),
-						deploymentName: apiv1.CloudflaredDeploymentNameForServiceAZ(gw, svc, az.Name),
-						secretName:     apiv1.TunnelTokenSecretNameForServiceAZ(gw, svc, az.Name),
-						azName:         az.Name,
-						serviceName:    svc,
+						tunnelName:       apiv1.TunnelNameForServiceAZ(gw, svc.Namespace, svc.Name, az.Name),
+						deploymentName:   apiv1.CloudflaredDeploymentNameForServiceAZ(gw, svc.Name, az.Name),
+						secretName:       apiv1.TunnelTokenSecretNameForServiceAZ(gw, svc.Name, az.Name),
+						azName:           az.Name,
+						serviceNamespace: svc.Namespace,
+						serviceName:      svc.Name,
 					})
 				}
 			} else {
 				entries = append(entries, tunnelEntry{
-					tunnelName:     apiv1.TunnelNameForService(gw, svc),
-					deploymentName: apiv1.CloudflaredDeploymentNameForService(gw, svc),
-					secretName:     apiv1.TunnelTokenSecretNameForService(gw, svc),
-					serviceName:    svc,
+					tunnelName:       apiv1.TunnelNameForService(gw, svc.Namespace, svc.Name),
+					deploymentName:   apiv1.CloudflaredDeploymentNameForService(gw, svc.Name),
+					secretName:       apiv1.TunnelTokenSecretNameForService(gw, svc.Name),
+					serviceNamespace: svc.Namespace,
+					serviceName:      svc.Name,
 				})
 			}
 		}
@@ -212,23 +214,42 @@ func computeDesiredTunnels(gw *gatewayv1.Gateway, mode lbMode, params *apiv1.Clo
 	}
 }
 
-// collectUniqueServices extracts unique Service names from the backendRefs of
-// valid HTTPRoutes, sorted alphabetically for deterministic ordering.
-func collectUniqueServices(routes []*gatewayv1.HTTPRoute) []string {
-	seen := make(map[string]struct{})
-	var services []string
+// collectUniqueServices extracts unique namespace-qualified Service references
+// from the backendRefs of valid HTTPRoutes, sorted deterministically. The
+// namespace defaults to the route's namespace when not specified on the ref.
+func collectUniqueServices(routes []*gatewayv1.HTTPRoute) []types.NamespacedName {
+	seen := make(map[types.NamespacedName]struct{})
+	var services []types.NamespacedName
 	for _, route := range routes {
 		for _, rule := range route.Spec.Rules {
 			for _, ref := range rule.BackendRefs {
-				name := string(ref.Name)
-				if _, ok := seen[name]; !ok {
-					seen[name] = struct{}{}
-					services = append(services, name)
+				ns := route.Namespace
+				if ref.Namespace != nil {
+					ns = string(*ref.Namespace)
+				}
+				key := types.NamespacedName{Namespace: ns, Name: string(ref.Name)}
+				if _, ok := seen[key]; !ok {
+					seen[key] = struct{}{}
+					services = append(services, key)
 				}
 			}
 		}
 	}
-	slices.Sort(services)
+	slices.SortFunc(services, func(a, b types.NamespacedName) int {
+		if a.Namespace != b.Namespace {
+			if a.Namespace < b.Namespace {
+				return -1
+			}
+			return 1
+		}
+		if a.Name < b.Name {
+			return -1
+		}
+		if a.Name > b.Name {
+			return 1
+		}
+		return 0
+	})
 	return services
 }
 
@@ -351,12 +372,13 @@ func (r *GatewayReconciler) reconcileCGS(
 	// Tunnels.
 	for _, e := range entries {
 		desired.Tunnels = append(desired.Tunnels, apiv1.TunnelStatus{
-			Name:           e.tunnelName,
-			ID:             e.tunnelID,
-			DeploymentName: e.deploymentName,
-			SecretName:     e.secretName,
-			AZName:         e.azName,
-			ServiceName:    e.serviceName,
+			Name:             e.tunnelName,
+			ID:               e.tunnelID,
+			DeploymentName:   e.deploymentName,
+			SecretName:       e.secretName,
+			AZName:           e.azName,
+			ServiceNamespace: e.serviceNamespace,
+			ServiceName:      e.serviceName,
 		})
 	}
 
@@ -433,6 +455,33 @@ func (r *GatewayReconciler) reconcileCGS(
 		}
 	}
 	return cgs, nil
+}
+
+// cgsTunnels extracts the tunnel statuses from a CloudflareGatewayStatus.
+// Returns nil if the CGS is nil.
+func cgsTunnels(cgs *apiv1.CloudflareGatewayStatus) []apiv1.TunnelStatus {
+	if cgs == nil {
+		return nil
+	}
+	return cgs.Status.Tunnels
+}
+
+// cgsLBHostnames extracts the LB hostnames from a CloudflareGatewayStatus.
+// Returns nil if the CGS is nil or has no LB state.
+func cgsLBHostnames(cgs *apiv1.CloudflareGatewayStatus) []string {
+	if cgs == nil || cgs.Status.LoadBalancer == nil {
+		return nil
+	}
+	return cgs.Status.LoadBalancer.Hostnames
+}
+
+// cgsLBPools extracts the LB pool statuses from a CloudflareGatewayStatus.
+// Returns nil if the CGS is nil or has no LB state.
+func cgsLBPools(cgs *apiv1.CloudflareGatewayStatus) []apiv1.PoolStatus {
+	if cgs == nil || cgs.Status.LoadBalancer == nil {
+		return nil
+	}
+	return cgs.Status.LoadBalancer.Pools
 }
 
 // cgsZoneInfo extracts the DNS zone name and ID from a CloudflareGatewayStatus.

--- a/internal/controller/gateway_ingress.go
+++ b/internal/controller/gateway_ingress.go
@@ -45,7 +45,7 @@ func (r *GatewayReconciler) reconcileAllTunnelIngress(ctx context.Context, tc cl
 		switch {
 		case mode == lbModePerBackendRef && e.serviceName != "":
 			// Per-backendRef: route all hostnames to this tunnel's single service.
-			ingress = buildIngressRulesForService(routes, e.serviceName)
+			ingress = buildIngressRulesForService(routes, e.serviceNamespace, e.serviceName)
 		default:
 			// Simple / per-AZ: full ingress on every tunnel.
 			ingress = fullIngress
@@ -69,17 +69,17 @@ func (r *GatewayReconciler) reconcileAllTunnelIngress(ctx context.Context, tc cl
 // buildIngressRulesForService builds ingress rules that route all hostnames
 // referencing a given Service to that service, with a catch-all 404. Used in
 // per-backendRef (TrafficSplitting) mode where each tunnel handles one service.
-func buildIngressRulesForService(routes []*gatewayv1.HTTPRoute, serviceName string) []cloudflare.IngressRule {
+func buildIngressRulesForService(routes []*gatewayv1.HTTPRoute, serviceNamespace, serviceName string) []cloudflare.IngressRule {
 	var rules []cloudflare.IngressRule
 	for _, route := range routes {
 		for _, rule := range route.Spec.Rules {
 			for _, ref := range rule.BackendRefs {
-				if string(ref.Name) != serviceName {
-					continue
-				}
 				ns := route.Namespace
 				if ref.Namespace != nil {
 					ns = string(*ref.Namespace)
+				}
+				if string(ref.Name) != serviceName || ns != serviceNamespace {
+					continue
 				}
 				port := int32(80)
 				if ref.Port != nil {

--- a/internal/controller/gateway_loadbalancer.go
+++ b/internal/controller/gateway_loadbalancer.go
@@ -27,7 +27,12 @@ type lbReconcileState struct {
 // reconcileLoadBalancer creates or updates the Cloudflare Load Balancer
 // infrastructure: a health monitor, pools (per-AZ or per-Service depending
 // on the topology), and one load balancer per hostname. Stale LBs and pools
-// are cleaned up.
+// are cleaned up. previousHostnames is the list of LB hostnames from the
+// previous reconciliation (from CGS.Status.LoadBalancer.Hostnames); stale
+// hostnames are those in previousHostnames but not in the desired set.
+// previousPools is the list of LB pools from the previous reconciliation
+// (from CGS.Status.LoadBalancer.Pools); stale pools are those in
+// previousPools but not in the desired set.
 func (r *GatewayReconciler) reconcileLoadBalancer(
 	ctx context.Context,
 	tc cloudflare.Client,
@@ -36,6 +41,8 @@ func (r *GatewayReconciler) reconcileLoadBalancer(
 	mode lbMode,
 	entries []tunnelEntry,
 	validRoutes []*gatewayv1.HTTPRoute,
+	previousHostnames []string,
+	previousPools []apiv1.PoolStatus,
 ) (lbReconcileState, []string, []string) {
 	l := log.FromContext(ctx)
 	var state lbReconcileState
@@ -51,6 +58,7 @@ func (r *GatewayReconciler) reconcileLoadBalancer(
 
 	// 1. Ensure monitor.
 	monitorName := apiv1.MonitorName(gw)
+	monitorDesc := apiv1.ResourceDescription(gw)
 	state.monitorName = monitorName
 	resolved := apiv1.ResolveMonitorConfig(params.Spec.LoadBalancer)
 	monitorCfg := cloudflare.MonitorConfig{
@@ -65,11 +73,11 @@ func (r *GatewayReconciler) reconcileLoadBalancer(
 		return state, nil, []string{fmt.Sprintf("failed to look up monitor %q: %v", monitorName, err)}
 	}
 	if monitorID != "" {
-		if err := tc.UpdateMonitor(ctx, monitorID, monitorName, monitorCfg); err != nil {
+		if err := tc.UpdateMonitor(ctx, monitorID, monitorName, monitorDesc, monitorCfg); err != nil {
 			return state, nil, []string{fmt.Sprintf("failed to update monitor %q: %v", monitorName, err)}
 		}
 	} else {
-		monitorID, err = tc.CreateMonitor(ctx, monitorName, monitorCfg)
+		monitorID, err = tc.CreateMonitor(ctx, monitorName, monitorDesc, monitorCfg)
 		if err != nil {
 			return state, nil, []string{fmt.Sprintf("failed to create monitor %q: %v", monitorName, err)}
 		}
@@ -126,9 +134,10 @@ func (r *GatewayReconciler) reconcileLoadBalancer(
 	desiredHostnames := computeDesiredHostnames(validRoutes, zoneName)
 	state.hostnames = desiredHostnames
 
+	lbDesc := apiv1.ResourceDescription(gw)
 	for _, hostname := range desiredHostnames {
 		poolIDs, poolWeights := computeLBPoolsForHostname(hostname, mode, gw, params, validRoutes, poolIDMap)
-		if err := tc.EnsureLoadBalancer(ctx, zoneID, hostname, poolIDs, steeringPolicy, sessionAffinity, poolWeights); err != nil {
+		if err := tc.EnsureLoadBalancer(ctx, zoneID, hostname, poolIDs, steeringPolicy, sessionAffinity, lbDesc, poolWeights); err != nil {
 			errs = append(errs, fmt.Sprintf("failed to ensure load balancer for %q: %v", hostname, err))
 			continue
 		}
@@ -139,21 +148,12 @@ func (r *GatewayReconciler) reconcileLoadBalancer(
 		return state, changes, errs
 	}
 
-	// 5. Cleanup stale load balancers.
+	// 5. Cleanup stale load balancers (in previous CGS but not in desired).
 	desiredHostnameSet := make(map[string]struct{}, len(desiredHostnames))
 	for _, h := range desiredHostnames {
 		desiredHostnameSet[h] = struct{}{}
 	}
-	existingHostnames, err := tc.ListLoadBalancerHostnames(ctx, zoneID)
-	if err != nil {
-		errs = append(errs, fmt.Sprintf("failed to list load balancer hostnames: %v", err))
-		return state, changes, errs
-	}
-	// Only consider hostnames in our zone for cleanup.
-	for _, h := range existingHostnames {
-		if !hostnameInZone(h, zoneName) {
-			continue
-		}
+	for _, h := range previousHostnames {
 		if _, ok := desiredHostnameSet[h]; ok {
 			continue
 		}
@@ -165,19 +165,16 @@ func (r *GatewayReconciler) reconcileLoadBalancer(
 		l.V(1).Info("Deleted stale load balancer", "hostname", h)
 	}
 
-	// 6. Cleanup stale pools.
+	// 6. Cleanup stale pools (in previous CGS but not in desired).
 	desiredPoolNames := make(map[string]struct{}, len(desiredPools))
 	for _, dp := range desiredPools {
 		desiredPoolNames[dp.Name] = struct{}{}
 	}
-	prefix := "gateway-" + string(gw.UID)
-	existingPools, err := tc.ListPoolsByPrefix(ctx, prefix)
-	if err != nil {
-		errs = append(errs, fmt.Sprintf("failed to list pools for cleanup: %v", err))
-		return state, changes, errs
-	}
-	for _, p := range existingPools {
+	for _, p := range previousPools {
 		if _, ok := desiredPoolNames[p.Name]; ok {
+			continue
+		}
+		if p.ID == "" {
 			continue
 		}
 		if err := tc.DeletePool(ctx, p.ID); err != nil {
@@ -194,12 +191,18 @@ func (r *GatewayReconciler) reconcileLoadBalancer(
 // cleanupAllLBResources deletes all LB resources for a Gateway: load balancers,
 // pools, and the monitor. Used when switching from LB mode to simple mode or
 // during finalization. zoneName and zoneID identify the DNS zone; if either is
-// empty, no cleanup is performed.
+// empty, no cleanup is performed. ownedHostnames is the list of LB hostnames
+// owned by this gateway (from CGS.Status.LoadBalancer.Hostnames); only these
+// hostnames are deleted, preventing interference with other gateways or
+// external services sharing the same zone. ownedPools is the list of LB pools
+// owned by this gateway (from CGS.Status.LoadBalancer.Pools).
 func (r *GatewayReconciler) cleanupAllLBResources(
 	ctx context.Context,
 	tc cloudflare.Client,
 	gw *gatewayv1.Gateway,
 	zoneName, zoneID string,
+	ownedHostnames []string,
+	ownedPools []apiv1.PoolStatus,
 ) ([]string, []string) {
 	l := log.FromContext(ctx)
 	var changes []string
@@ -210,37 +213,30 @@ func (r *GatewayReconciler) cleanupAllLBResources(
 	}
 
 	// Delete load balancers first (they reference pools).
-	hostnames, err := tc.ListLoadBalancerHostnames(ctx, zoneID)
-	if err != nil {
-		errs = append(errs, fmt.Sprintf("failed to list load balancer hostnames for cleanup: %v", err))
-	} else {
-		for _, h := range hostnames {
-			if !hostnameInZone(h, zoneName) {
-				continue
-			}
-			if err := tc.DeleteLoadBalancer(ctx, zoneID, h); err != nil {
-				errs = append(errs, fmt.Sprintf("failed to delete load balancer for %q: %v", h, err))
-				continue
-			}
-			changes = append(changes, fmt.Sprintf("deleted load balancer for %s", h))
-			l.V(1).Info("Deleted load balancer", "hostname", h)
+	// Only delete hostnames owned by this gateway (from CGS), not all zone LBs.
+	for _, h := range ownedHostnames {
+		if !hostnameInZone(h, zoneName) {
+			continue
 		}
+		if err := tc.DeleteLoadBalancer(ctx, zoneID, h); err != nil {
+			errs = append(errs, fmt.Sprintf("failed to delete load balancer for %q: %v", h, err))
+			continue
+		}
+		changes = append(changes, fmt.Sprintf("deleted load balancer for %s", h))
+		l.V(1).Info("Deleted load balancer", "hostname", h)
 	}
 
 	// Delete pools (they reference the monitor).
-	prefix := "gateway-" + string(gw.UID)
-	pools, err := tc.ListPoolsByPrefix(ctx, prefix)
-	if err != nil {
-		errs = append(errs, fmt.Sprintf("failed to list pools for cleanup: %v", err))
-	} else {
-		for _, p := range pools {
-			if err := tc.DeletePool(ctx, p.ID); err != nil {
-				errs = append(errs, fmt.Sprintf("failed to delete pool %q: %v", p.Name, err))
-				continue
-			}
-			changes = append(changes, fmt.Sprintf("deleted pool %s", p.Name))
-			l.V(1).Info("Deleted pool", "pool", p.Name, "poolID", p.ID)
+	for _, p := range ownedPools {
+		if p.ID == "" {
+			continue
 		}
+		if err := tc.DeletePool(ctx, p.ID); err != nil {
+			errs = append(errs, fmt.Sprintf("failed to delete pool %q: %v", p.Name, err))
+			continue
+		}
+		changes = append(changes, fmt.Sprintf("deleted pool %s", p.Name))
+		l.V(1).Info("Deleted pool", "pool", p.Name, "poolID", p.ID)
 	}
 
 	// Delete monitor.
@@ -274,9 +270,10 @@ func computeDesiredPools(
 		pools := make([]cloudflare.PoolConfig, 0, len(entries))
 		for _, e := range entries {
 			pools = append(pools, cloudflare.PoolConfig{
-				Name:    apiv1.PoolNameForAZ(gw, e.azName),
-				Weight:  1,
-				Enabled: true,
+				Name:        apiv1.PoolNameForAZ(gw, e.azName),
+				Description: apiv1.ResourceDescription(gw, "az:"+e.azName),
+				Weight:      1,
+				Enabled:     true,
 				Origins: []cloudflare.PoolOrigin{{
 					Name:    e.azName,
 					Address: cloudflare.TunnelTarget(e.tunnelID),
@@ -292,10 +289,10 @@ func computeDesiredPools(
 		services := collectUniqueServices(validRoutes)
 		hasAZs := params.Spec.Tunnels != nil && len(params.Spec.Tunnels.AvailabilityZones) > 0
 
-		// Build a lookup from (serviceName, azName) -> tunnelID.
+		// Build a lookup from "svcNs/svcName[/azName]" -> tunnelID.
 		tunnelLookup := make(map[string]string, len(entries))
 		for _, e := range entries {
-			key := e.serviceName
+			key := e.serviceNamespace + "/" + e.serviceName
 			if e.azName != "" {
 				key += "/" + e.azName
 			}
@@ -304,14 +301,16 @@ func computeDesiredPools(
 
 		pools := make([]cloudflare.PoolConfig, 0, len(services))
 		for _, svc := range services {
+			svcKey := svc.Namespace + "/" + svc.Name
 			pool := cloudflare.PoolConfig{
-				Name:    apiv1.PoolNameForService(gw, svc),
-				Weight:  1,
-				Enabled: true,
+				Name:        apiv1.PoolNameForService(gw, svc.Namespace, svc.Name),
+				Description: apiv1.ResourceDescription(gw, "svc:"+svcKey),
+				Weight:      1,
+				Enabled:     true,
 			}
 			if hasAZs {
 				for _, az := range params.Spec.Tunnels.AvailabilityZones {
-					key := svc + "/" + az.Name
+					key := svcKey + "/" + az.Name
 					tunnelID := tunnelLookup[key]
 					if tunnelID == "" {
 						continue
@@ -324,10 +323,10 @@ func computeDesiredPools(
 					})
 				}
 			} else {
-				tunnelID := tunnelLookup[svc]
+				tunnelID := tunnelLookup[svcKey]
 				if tunnelID != "" {
 					pool.Origins = append(pool.Origins, cloudflare.PoolOrigin{
-						Name:    svc,
+						Name:    svc.Name,
 						Address: cloudflare.TunnelTarget(tunnelID),
 						Enabled: true,
 						Weight:  1,
@@ -386,8 +385,9 @@ func computeLBPoolsForHostname(
 
 	case lbModePerBackendRef:
 		// TrafficSplitting: only pools for services referenced on this hostname,
-		// with weights from backendRef weights.
-		weightSums := make(map[string]int32)
+		// with weights from backendRef weights. Key is "namespace/name".
+		type svcKey struct{ Namespace, Name string }
+		weightSums := make(map[svcKey]int32)
 		for _, route := range validRoutes {
 			routeHasHostname := false
 			for _, h := range route.Spec.Hostnames {
@@ -401,12 +401,16 @@ func computeLBPoolsForHostname(
 			}
 			for _, rule := range route.Spec.Rules {
 				for _, ref := range rule.BackendRefs {
-					svc := string(ref.Name)
+					ns := route.Namespace
+					if ref.Namespace != nil {
+						ns = string(*ref.Namespace)
+					}
+					key := svcKey{Namespace: ns, Name: string(ref.Name)}
 					weight := int32(1)
 					if ref.Weight != nil {
 						weight = *ref.Weight
 					}
-					weightSums[svc] += weight
+					weightSums[key] += weight
 				}
 			}
 		}
@@ -418,16 +422,12 @@ func computeLBPoolsForHostname(
 		}
 
 		poolWeights = make(map[string]float64, len(weightSums))
-		services := make([]string, 0, len(weightSums))
-		for svc := range weightSums {
-			services = append(services, svc)
-		}
-		for _, svc := range services {
-			poolName := apiv1.PoolNameForService(gw, svc)
+		for svc, w := range weightSums {
+			poolName := apiv1.PoolNameForService(gw, svc.Namespace, svc.Name)
 			if id, ok := poolIDMap[poolName]; ok {
 				poolIDs = append(poolIDs, id)
 				if totalWeight > 0 {
-					poolWeights[id] = float64(weightSums[svc]) / float64(totalWeight)
+					poolWeights[id] = float64(w) / float64(totalWeight)
 				}
 			}
 		}

--- a/internal/controller/gateway_tunnels.go
+++ b/internal/controller/gateway_tunnels.go
@@ -273,7 +273,7 @@ func removeOwnerRef(obj client.Object, ownerUID types.UID) bool {
 // cleanupStaleTunnelResources deletes Deployments, Secrets, and Cloudflare tunnels
 // that are no longer part of the desired tunnel entries. This handles AZ
 // addition/removal, service changes, and mode switches.
-func (r *GatewayReconciler) cleanupStaleTunnelResources(ctx context.Context, tc cloudflare.Client, gw *gatewayv1.Gateway, entries []tunnelEntry) ([]string, []string) {
+func (r *GatewayReconciler) cleanupStaleTunnelResources(ctx context.Context, tc cloudflare.Client, gw *gatewayv1.Gateway, entries []tunnelEntry, previousTunnels []apiv1.TunnelStatus) ([]string, []string) {
 	l := log.FromContext(ctx)
 
 	// Build set of desired Deployment names.
@@ -345,35 +345,30 @@ func (r *GatewayReconciler) cleanupStaleTunnelResources(ctx context.Context, tc 
 		l.V(1).Info("Deleted stale tunnel token Secret", "secret", secret.Name)
 	}
 
-	// Delete stale Cloudflare tunnels. List tunnels by prefix "gateway-{UID}"
-	// and delete any not in the desired set.
-	prefix := "gateway-" + string(gw.UID)
-	tunnels, err := tc.ListTunnels(ctx)
-	if err != nil {
-		errs = append(errs, fmt.Sprintf("failed to list tunnels for cleanup: %v", err))
-		return changes, errs
-	}
+	// Delete stale Cloudflare tunnels using CGS-tracked names (previous tunnels
+	// from CGS.Status.Tunnels). Compare against desired set and delete any
+	// that are no longer needed.
 	desiredTunnels := make(map[string]struct{}, len(entries))
 	for _, e := range entries {
 		desiredTunnels[e.tunnelName] = struct{}{}
 	}
-	for _, t := range tunnels {
-		if !strings.HasPrefix(t.Name, prefix) {
+	for _, prev := range previousTunnels {
+		if _, ok := desiredTunnels[prev.Name]; ok {
 			continue
 		}
-		if _, ok := desiredTunnels[t.Name]; ok {
+		if prev.ID == "" {
 			continue
 		}
-		if err := tc.CleanupTunnelConnections(ctx, t.ID); err != nil {
-			errs = append(errs, fmt.Sprintf("failed to cleanup connections for stale tunnel %s: %v", t.Name, err))
+		if err := tc.CleanupTunnelConnections(ctx, prev.ID); err != nil {
+			errs = append(errs, fmt.Sprintf("failed to cleanup connections for stale tunnel %s: %v", prev.Name, err))
 			continue
 		}
-		if err := tc.DeleteTunnel(ctx, t.ID); err != nil {
-			errs = append(errs, fmt.Sprintf("failed to delete stale tunnel %s: %v", t.Name, err))
+		if err := tc.DeleteTunnel(ctx, prev.ID); err != nil {
+			errs = append(errs, fmt.Sprintf("failed to delete stale tunnel %s: %v", prev.Name, err))
 			continue
 		}
-		changes = append(changes, fmt.Sprintf("deleted stale tunnel %s", t.Name))
-		l.V(1).Info("Deleted stale tunnel", "tunnelName", t.Name, "tunnelID", t.ID)
+		changes = append(changes, fmt.Sprintf("deleted stale tunnel %s", prev.Name))
+		l.V(1).Info("Deleted stale tunnel", "tunnelName", prev.Name, "tunnelID", prev.ID)
 	}
 
 	return changes, errs

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -145,6 +145,7 @@ func setupRBAC(cfg *rest.Config, s *runtime.Scheme) *rest.Config {
 }
 
 func TestMain(m *testing.M) {
+	apiv1.SetClusterName("test-cluster")
 	testCtx, testCancel = context.WithCancel(context.Background())
 
 	scheme := newTestScheme()
@@ -483,7 +484,7 @@ func (m *mockCloudflareClient) FindZoneIDByHostname(_ context.Context, hostname 
 	return "test-zone-id", nil
 }
 
-func (m *mockCloudflareClient) EnsureDNSCNAME(_ context.Context, zoneID, hostname, target string) error {
+func (m *mockCloudflareClient) EnsureDNSCNAME(_ context.Context, zoneID, hostname, target, _ string) error {
 	if m.ensureDNSErr != nil {
 		return m.ensureDNSErr
 	}
@@ -508,7 +509,7 @@ func (m *mockCloudflareClient) ListDNSCNAMEsByTarget(_ context.Context, _, _ str
 
 // --- Load Balancer mock methods ---
 
-func (m *mockCloudflareClient) CreateMonitor(_ context.Context, name string, _ cloudflare.MonitorConfig) (string, error) {
+func (m *mockCloudflareClient) CreateMonitor(_ context.Context, name, _ string, _ cloudflare.MonitorConfig) (string, error) {
 	if m.createMonitorErr != nil {
 		return "", m.createMonitorErr
 	}
@@ -531,7 +532,7 @@ func (m *mockCloudflareClient) GetMonitorByName(_ context.Context, name string) 
 	return "", nil
 }
 
-func (m *mockCloudflareClient) UpdateMonitor(_ context.Context, _, _ string, _ cloudflare.MonitorConfig) error {
+func (m *mockCloudflareClient) UpdateMonitor(_ context.Context, _, _, _ string, _ cloudflare.MonitorConfig) error {
 	if m.updateMonitorErr != nil {
 		return m.updateMonitorErr
 	}
@@ -606,7 +607,7 @@ func (m *mockCloudflareClient) ListPoolsByPrefix(_ context.Context, prefix strin
 	return result, nil
 }
 
-func (m *mockCloudflareClient) EnsureLoadBalancer(_ context.Context, zoneID, hostname string, poolIDs []string, steeringPolicy, sessionAffinity string, poolWeights map[string]float64) error {
+func (m *mockCloudflareClient) EnsureLoadBalancer(_ context.Context, zoneID, hostname string, poolIDs []string, steeringPolicy, sessionAffinity, _ string, poolWeights map[string]float64) error {
 	if m.ensureLBErr != nil {
 		return m.ensureLBErr
 	}

--- a/main.go
+++ b/main.go
@@ -62,6 +62,8 @@ func getGatewayAPIVersion() (*semver.Version, error) {
 func main() {
 	ctx := ctrl.SetupSignalHandler()
 
+	clusterName := pflag.String("cluster-name", "",
+		"unique cluster identifier for deterministic Cloudflare resource naming (required)")
 	cloudflaredImage := pflag.String("cloudflared-image",
 		controller.DefaultCloudflaredImage, "cloudflared container image")
 
@@ -70,6 +72,12 @@ func main() {
 	leaderElectionOptions := leaderelection.Options{}
 	leaderElectionOptions.BindFlags(pflag.CommandLine)
 	pflag.Parse()
+
+	if *clusterName == "" {
+		fmt.Fprintln(os.Stderr, "--cluster-name is required")
+		os.Exit(1)
+	}
+	apiv1.SetClusterName(*clusterName)
 
 	// Enable leader election by default.
 	if !pflag.CommandLine.Changed("enable-leader-election") {


### PR DESCRIPTION
## Summary

- Cloudflare resource names (tunnels, pools, monitors) are now derived from a SHA256 hash of `clusterName/namespace/gatewayName[/extra]` instead of the Gateway UID. This makes names deterministic across cluster recreations — a reborn cluster with the same `clusterName` automatically adopts existing Cloudflare resources instead of orphaning them.
- Added required `--cluster-name` flag to the controller and corresponding `config.clusterName` Helm value.
- Resource descriptions/comments are set on Cloudflare resources (pools, monitors, LBs, DNS records) for dashboard visibility.
- Stale resource cleanup now uses CGS-tracked names instead of prefix-based listing, scoping cleanup to the specific gateway being reconciled. This also eliminates Cloudflare API calls for garbage collection during the common "nothing changed" reconciliation path — previously every reconcile cycle listed all account pools and tunnels from the Cloudflare API to discover owned resources, even when nothing was stale.
- Added `test_cluster_recreation` e2e test to the simple suite proving that a cluster delete + recreate cycle reuses the same tunnel and DNS CNAME.

## Test plan

- [x] `make test` (unit + integration tests)
- [x] `make test-e2e` (simple topology — includes new `test_cluster_recreation`)
- [x] `make test-e2e-ha` (high availability topology)
- [x] `make test-e2e-ts` (traffic splitting topology)
- [x] `make test-e2e-ts-az` (traffic splitting with AZs topology)