### PR TITLE
Upgrade Gateway API to v1.5.0

### DIFF
--- a/charts/cloudflare-gateway-controller/crds/gateway-api.yaml
+++ b/charts/cloudflare-gateway-controller/crds/gateway-api.yaml
@@ -1,7 +1,7 @@
 # Copyright 2026 Matheus Pimenta.
 # SPDX-License-Identifier: AGPL-3.0
 
-# Copyright 2025 The Kubernetes Authors.
+# Copyright The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,8 +26,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.1
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.0
     gateway.networking.k8s.io/channel: experimental
   labels:
     gateway.networking.k8s.io/policy: Direct
@@ -102,8 +102,6 @@ spec:
               targetRefs:
                 description: |-
                   TargetRefs identifies an API object to apply the policy to.
-                  Only Services have Extended support. Implementations MAY support
-                  additional objects, with Implementation Specific support.
                   Note that this config applies to the entire referenced resource
                   by default, but this default may change in the future to provide
                   a more granular application of the policy.
@@ -124,9 +122,9 @@ spec:
                     example, a policy with a creation timestamp of "2021-07-15
                     01:02:03" MUST be given precedence over a policy with a
                     creation timestamp of "2021-07-15 01:02:04".
-                  * The policy appearing first in alphabetical order by {name}.
-                    For example, a policy named `bar` is given precedence over a
-                    policy named `baz`.
+                  * The policy appearing first in alphabetical order by {namespace}/{name}.
+                    For example, a policy named `foo/bar` is given precedence over a
+                    policy named `foo/baz`.
 
                   For any BackendTLSPolicy that does not take precedence, the
                   implementation MUST ensure the `Accepted` Condition is set to
@@ -138,9 +136,28 @@ spec:
                   clarified in a future release, the safest approach is to support a single
                   targetRef.
 
-                  Support: Extended for Kubernetes Service
+                  Support Levels:
 
-                  Support: Implementation-specific for any other resource
+                  * Extended: Kubernetes Service referenced by HTTPRoute backendRefs.
+
+                  * Implementation-Specific: Services not connected via HTTPRoute, and any
+                    other kind of backend. Implementations MAY use BackendTLSPolicy for:
+                    - Services not referenced by any Route (e.g., infrastructure services)
+                    - Gateway feature backends (e.g., ExternalAuth, rate-limiting services)
+                    - Service mesh workload-to-service communication
+                    - Other resource types beyond Service
+
+                  Implementations SHOULD aim to ensure that BackendTLSPolicy behavior is consistent,
+                  even outside of the extended HTTPRoute -(backendRef) -> Service path.
+                  They SHOULD clearly document how BackendTLSPolicy is interpreted in these
+                  scenarios, including:
+                    - Which resources beyond Service are supported
+                    - How the policy is discovered and applied
+                    - Any implementation-specific semantics or restrictions
+
+                  Note that this config applies to the entire referenced resource
+                  by default, but this default may change in the future to provide
+                  a more granular application of the policy.
                 items:
                   description: |-
                     LocalPolicyTargetReferenceWithSectionName identifies an API object to apply a
@@ -379,8 +396,8 @@ spec:
                     x-kubernetes-list-type: atomic
                   wellKnownCACertificates:
                     description: |-
-                      WellKnownCACertificates specifies whether system CA certificates may be used in
-                      the TLS handshake between the gateway and backend pod.
+                      WellKnownCACertificates specifies whether a well-known set of CA certificates
+                      may be used in the TLS handshake between the gateway and backend pod.
 
                       If WellKnownCACertificates is unspecified or empty (""), then CACertificateRefs
                       must be specified with at least one entry for a valid configuration. Only one of
@@ -390,9 +407,17 @@ spec:
                       `Accepted` Condition on the BackendTLSPolicy is set to `status: False`, with
                       a Reason `Invalid`.
 
+                      Valid values include:
+                      * "System" - indicates that well-known system CA certificates should be used.
+
+                      Implementations MAY define their own sets of CA certificates. Such definitions
+                      MUST use an implementation-specific, prefixed name, such as
+                      `mycompany.com/my-custom-ca-certificates`.
+
                       Support: Implementation-specific
-                    enum:
-                    - System
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^(System|([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]))$
                     type: string
                 required:
                 - hostname
@@ -771,8 +796,6 @@ spec:
               targetRefs:
                 description: |-
                   TargetRefs identifies an API object to apply the policy to.
-                  Only Services have Extended support. Implementations MAY support
-                  additional objects, with Implementation Specific support.
                   Note that this config applies to the entire referenced resource
                   by default, but this default may change in the future to provide
                   a more granular application of the policy.
@@ -793,9 +816,9 @@ spec:
                     example, a policy with a creation timestamp of "2021-07-15
                     01:02:03" MUST be given precedence over a policy with a
                     creation timestamp of "2021-07-15 01:02:04".
-                  * The policy appearing first in alphabetical order by {name}.
-                    For example, a policy named `bar` is given precedence over a
-                    policy named `baz`.
+                  * The policy appearing first in alphabetical order by {namespace}/{name}.
+                    For example, a policy named `foo/bar` is given precedence over a
+                    policy named `foo/baz`.
 
                   For any BackendTLSPolicy that does not take precedence, the
                   implementation MUST ensure the `Accepted` Condition is set to
@@ -807,9 +830,28 @@ spec:
                   clarified in a future release, the safest approach is to support a single
                   targetRef.
 
-                  Support: Extended for Kubernetes Service
+                  Support Levels:
 
-                  Support: Implementation-specific for any other resource
+                  * Extended: Kubernetes Service referenced by HTTPRoute backendRefs.
+
+                  * Implementation-Specific: Services not connected via HTTPRoute, and any
+                    other kind of backend. Implementations MAY use BackendTLSPolicy for:
+                    - Services not referenced by any Route (e.g., infrastructure services)
+                    - Gateway feature backends (e.g., ExternalAuth, rate-limiting services)
+                    - Service mesh workload-to-service communication
+                    - Other resource types beyond Service
+
+                  Implementations SHOULD aim to ensure that BackendTLSPolicy behavior is consistent,
+                  even outside of the extended HTTPRoute -(backendRef) -> Service path.
+                  They SHOULD clearly document how BackendTLSPolicy is interpreted in these
+                  scenarios, including:
+                    - Which resources beyond Service are supported
+                    - How the policy is discovered and applied
+                    - Any implementation-specific semantics or restrictions
+
+                  Note that this config applies to the entire referenced resource
+                  by default, but this default may change in the future to provide
+                  a more granular application of the policy.
                 items:
                   description: |-
                     LocalPolicyTargetReferenceWithSectionName identifies an API object to apply a
@@ -1048,8 +1090,8 @@ spec:
                     x-kubernetes-list-type: atomic
                   wellKnownCACertificates:
                     description: |-
-                      WellKnownCACertificates specifies whether system CA certificates may be used in
-                      the TLS handshake between the gateway and backend pod.
+                      WellKnownCACertificates specifies whether a well-known set of CA certificates
+                      may be used in the TLS handshake between the gateway and backend pod.
 
                       If WellKnownCACertificates is unspecified or empty (""), then CACertificateRefs
                       must be specified with at least one entry for a valid configuration. Only one of
@@ -1059,9 +1101,17 @@ spec:
                       `Accepted` Condition on the BackendTLSPolicy is set to `status: False`, with
                       a Reason `Invalid`.
 
+                      Valid values include:
+                      * "System" - indicates that well-known system CA certificates should be used.
+
+                      Implementations MAY define their own sets of CA certificates. Such definitions
+                      MUST use an implementation-specific, prefixed name, such as
+                      `mycompany.com/my-custom-ca-certificates`.
+
                       Support: Implementation-specific
-                    enum:
-                    - System
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^(System|([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]))$
                     type: string
                 required:
                 - hostname
@@ -1398,8 +1448,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.1
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.0
     gateway.networking.k8s.io/channel: experimental
   name: gatewayclasses.gateway.networking.k8s.io
 spec:
@@ -1917,8 +1967,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.1
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.0
     gateway.networking.k8s.io/channel: experimental
   name: gateways.gateway.networking.k8s.io
 spec:
@@ -2053,14 +2103,14 @@ spec:
               allowedListeners:
                 description: |-
                   AllowedListeners defines which ListenerSets can be attached to this Gateway.
-                  While this feature is experimental, the default value is to allow no ListenerSets.
+                  The default value is to allow no ListenerSets.
                 properties:
                   namespaces:
                     default:
                       from: None
                     description: |-
                       Namespaces defines which namespaces ListenerSets can be attached to this Gateway.
-                      While this feature is experimental, the default value is to allow no ListenerSets.
+                      The default value is to allow no ListenerSets.
                     properties:
                       from:
                         default: None
@@ -2073,7 +2123,7 @@ spec:
                           * All: ListenerSets in all namespaces may be attached to this Gateway.
                           * None: Only listeners defined in the Gateway's spec are allowed
 
-                          While this feature is experimental, the default value None
+                          The default value None
                         enum:
                         - All
                         - Selector
@@ -2622,7 +2672,7 @@ spec:
                           the Gateway SHOULD return a 421.
                         * If the current Listener (selected by SNI matching during ClientHello)
                           does not match the Host:
-                            * If another Listener does match the Host the Gateway SHOULD return a
+                            * If another Listener does match the Host, the Gateway SHOULD return a
                               421.
                             * If no other Listener matches the Host, the Gateway MUST return a
                               404.
@@ -2833,6 +2883,9 @@ spec:
                 - message: tls mode must be Terminate for protocol HTTPS
                   rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode
                     == '''' || l.tls.mode == ''Terminate'') : true)'
+                - message: tls mode must be set for protocol TLS
+                  rule: 'self.all(l, (l.protocol == ''TLS'' ? has(l.tls) && has(l.tls.mode)
+                    && l.tls.mode != '''' : true))'
                 - message: hostname must not be specified for protocols ['TCP', 'UDP']
                   rule: 'self.all(l, l.protocol in [''TCP'', ''UDP'']  ? (!has(l.hostname)
                     || l.hostname == '''') : true)'
@@ -2862,19 +2915,30 @@ spec:
                     properties:
                       clientCertificateRef:
                         description: |-
-                          ClientCertificateRef is a reference to an object that contains a Client
-                          Certificate and the associated private key.
+                          ClientCertificateRef references an object that contains a client certificate
+                          and its associated private key. It can reference standard Kubernetes resources,
+                          i.e., Secret, or implementation-specific custom resources.
 
-                          References to a resource in different namespace are invalid UNLESS there
-                          is a ReferenceGrant in the target namespace that allows the certificate
-                          to be attached. If a ReferenceGrant does not allow this reference, the
-                          "ResolvedRefs" condition MUST be set to False for this listener with the
-                          "RefNotPermitted" reason.
+                          A ClientCertificateRef is considered invalid if:
 
-                          ClientCertificateRef can reference to standard Kubernetes resources, i.e.
-                          Secret, or implementation-specific custom resources.
+                          * It refers to a resource that cannot be resolved (e.g., the referenced resource
+                            does not exist) or is misconfigured (e.g., a Secret does not contain the keys
+                            named `tls.crt` and `tls.key`). In this case, the `ResolvedRefs` condition
+                            on the Gateway MUST be set to False with the Reason `InvalidClientCertificateRef`
+                            and the Message of the Condition MUST indicate why the reference is invalid.
 
-                          Support: Core
+                          * It refers to a resource in another namespace UNLESS there is a ReferenceGrant
+                            in the target namespace that allows the certificate to be attached.
+                            If a ReferenceGrant does not allow this reference, the `ResolvedRefs` condition
+                            on the Gateway MUST be set to False with the Reason `RefNotPermitted`.
+
+                          Implementations MAY choose to perform further validation of the certificate
+                          content (e.g., checking expiry or enforcing specific formats). In such cases,
+                          an implementation-specific Reason and Message MUST be set.
+
+                          Support: Core - Reference to a Kubernetes TLS Secret (with the type `kubernetes.io/tls`).
+                          Support: Implementation-specific - Other resource kinds or Secrets with a
+                          different type (e.g., `Opaque`).
                         properties:
                           group:
                             default: ""
@@ -2941,27 +3005,49 @@ spec:
                             properties:
                               caCertificateRefs:
                                 description: |-
-                                  CACertificateRefs contains one or more references to
-                                  Kubernetes objects that contain TLS certificates of
-                                  the Certificate Authorities that can be used
-                                  as a trust anchor to validate the certificates presented by the client.
+                                  CACertificateRefs contains one or more references to Kubernetes
+                                  objects that contain a PEM-encoded TLS CA certificate bundle, which
+                                  is used as a trust anchor to validate the certificates presented by
+                                  the client.
 
-                                  A single CA certificate reference to a Kubernetes ConfigMap
-                                  has "Core" support.
-                                  Implementations MAY choose to support attaching multiple CA certificates to
-                                  a Listener, but this behavior is implementation-specific.
+                                  A CACertificateRef is invalid if:
 
-                                  Support: Core - A single reference to a Kubernetes ConfigMap
-                                  with the CA certificate in a key named `ca.crt`.
+                                  * It refers to a resource that cannot be resolved (e.g., the
+                                    referenced resource does not exist) or is misconfigured (e.g., a
+                                    ConfigMap does not contain a key named `ca.crt`). In this case, the
+                                    Reason on all matching HTTPS listeners must be set to `InvalidCACertificateRef`
+                                    and the Message of the Condition must indicate which reference is invalid and why.
 
-                                  Support: Implementation-specific (More than one certificate in a ConfigMap
-                                  with different keys or more than one reference, or other kinds of resources).
+                                  * It refers to an unknown or unsupported kind of resource. In this
+                                    case, the Reason on all matching HTTPS listeners must be set to
+                                    `InvalidCACertificateKind` and the Message of the Condition must explain
+                                    which kind of resource is unknown or unsupported.
 
-                                  References to a resource in a different namespace are invalid UNLESS there
-                                  is a ReferenceGrant in the target namespace that allows the certificate
-                                  to be attached. If a ReferenceGrant does not allow this reference, the
-                                  "ResolvedRefs" condition MUST be set to False for this listener with the
-                                  "RefNotPermitted" reason.
+                                  * It refers to a resource in another namespace UNLESS there is a
+                                    ReferenceGrant in the target namespace that allows the CA
+                                    certificate to be attached. If a ReferenceGrant does not allow this
+                                    reference, the `ResolvedRefs` on all matching HTTPS listeners condition
+                                    MUST be set with the Reason `RefNotPermitted`.
+
+                                  Implementations MAY choose to perform further validation of the
+                                  certificate content (e.g., checking expiry or enforcing specific formats).
+                                  In such cases, an implementation-specific Reason and Message MUST be set.
+
+                                  In all cases, the implementation MUST ensure that the `ResolvedRefs`
+                                  condition is set to `status: False` on all targeted listeners (i.e.,
+                                  listeners serving HTTPS on a matching port). The condition MUST
+                                  include a Reason and Message that indicate the cause of the error. If
+                                  ALL CACertificateRefs are invalid, the implementation MUST also ensure
+                                  the `Accepted` condition on the listener is set to `status: False`, with
+                                  the Reason `NoValidCACertificate`.
+                                  Implementations MAY choose to support attaching multiple CA certificates
+                                  to a listener, but this behavior is implementation-specific.
+
+                                  Support: Core - A single reference to a Kubernetes ConfigMap, with the
+                                  CA certificate in a key named `ca.crt`.
+
+                                  Support: Implementation-specific - More than one reference, other kinds
+                                  of resources, or a single reference that includes multiple certificates.
                                 items:
                                   description: |-
                                     ObjectReference identifies an API object including its namespace.
@@ -3084,27 +3170,49 @@ spec:
                                   properties:
                                     caCertificateRefs:
                                       description: |-
-                                        CACertificateRefs contains one or more references to
-                                        Kubernetes objects that contain TLS certificates of
-                                        the Certificate Authorities that can be used
-                                        as a trust anchor to validate the certificates presented by the client.
+                                        CACertificateRefs contains one or more references to Kubernetes
+                                        objects that contain a PEM-encoded TLS CA certificate bundle, which
+                                        is used as a trust anchor to validate the certificates presented by
+                                        the client.
 
-                                        A single CA certificate reference to a Kubernetes ConfigMap
-                                        has "Core" support.
-                                        Implementations MAY choose to support attaching multiple CA certificates to
-                                        a Listener, but this behavior is implementation-specific.
+                                        A CACertificateRef is invalid if:
 
-                                        Support: Core - A single reference to a Kubernetes ConfigMap
-                                        with the CA certificate in a key named `ca.crt`.
+                                        * It refers to a resource that cannot be resolved (e.g., the
+                                          referenced resource does not exist) or is misconfigured (e.g., a
+                                          ConfigMap does not contain a key named `ca.crt`). In this case, the
+                                          Reason on all matching HTTPS listeners must be set to `InvalidCACertificateRef`
+                                          and the Message of the Condition must indicate which reference is invalid and why.
 
-                                        Support: Implementation-specific (More than one certificate in a ConfigMap
-                                        with different keys or more than one reference, or other kinds of resources).
+                                        * It refers to an unknown or unsupported kind of resource. In this
+                                          case, the Reason on all matching HTTPS listeners must be set to
+                                          `InvalidCACertificateKind` and the Message of the Condition must explain
+                                          which kind of resource is unknown or unsupported.
 
-                                        References to a resource in a different namespace are invalid UNLESS there
-                                        is a ReferenceGrant in the target namespace that allows the certificate
-                                        to be attached. If a ReferenceGrant does not allow this reference, the
-                                        "ResolvedRefs" condition MUST be set to False for this listener with the
-                                        "RefNotPermitted" reason.
+                                        * It refers to a resource in another namespace UNLESS there is a
+                                          ReferenceGrant in the target namespace that allows the CA
+                                          certificate to be attached. If a ReferenceGrant does not allow this
+                                          reference, the `ResolvedRefs` on all matching HTTPS listeners condition
+                                          MUST be set with the Reason `RefNotPermitted`.
+
+                                        Implementations MAY choose to perform further validation of the
+                                        certificate content (e.g., checking expiry or enforcing specific formats).
+                                        In such cases, an implementation-specific Reason and Message MUST be set.
+
+                                        In all cases, the implementation MUST ensure that the `ResolvedRefs`
+                                        condition is set to `status: False` on all targeted listeners (i.e.,
+                                        listeners serving HTTPS on a matching port). The condition MUST
+                                        include a Reason and Message that indicate the cause of the error. If
+                                        ALL CACertificateRefs are invalid, the implementation MUST also ensure
+                                        the `Accepted` condition on the listener is set to `status: False`, with
+                                        the Reason `NoValidCACertificate`.
+                                        Implementations MAY choose to support attaching multiple CA certificates
+                                        to a listener, but this behavior is implementation-specific.
+
+                                        Support: Core - A single reference to a Kubernetes ConfigMap, with the
+                                        CA certificate in a key named `ca.crt`.
+
+                                        Support: Implementation-specific - More than one reference, other kinds
+                                        of resources, or a single reference that includes multiple certificates.
                                       items:
                                         description: |-
                                           ObjectReference identifies an API object including its namespace.
@@ -3278,6 +3386,20 @@ spec:
                 maxItems: 16
                 type: array
                 x-kubernetes-list-type: atomic
+              attachedListenerSets:
+                description: |-
+                  AttachedListenerSets represents the total number of ListenerSets that have been
+                  successfully attached to this Gateway.
+
+                  A ListenerSet is successfully attached to a Gateway when all the following conditions are met:
+                  - The ListenerSet is selected by the Gateway's AllowedListeners field
+                  - The ListenerSet has a valid ParentRef selecting the Gateway
+                  - The ListenerSet's status has the condition "Accepted: true"
+
+                  Uses for this field include troubleshooting AttachedListenerSets attachment and
+                  measuring blast radius/impact of changes to a Gateway.
+                format: int32
+                type: integer
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"
@@ -3382,8 +3504,11 @@ spec:
                         attachment semantics can be found in the documentation on the various
                         Route kinds ParentRefs fields). Listener or Route status does not impact
                         successful attachment, i.e. the AttachedRoutes field count MUST be set
-                        for Listeners with condition Accepted: false and MUST count successfully
-                        attached Routes that may themselves have Accepted: false conditions.
+                        for Listeners, even if the Accepted condition of an individual Listener is set
+                        to "False". The AttachedRoutes number represents the number of Routes with
+                        the Accepted condition set to "True" that have been attached to this Listener.
+                        Routes with any other value for the Accepted condition MUST NOT be included
+                        in this count.
 
                         Uses for this field include troubleshooting Route attachment and
                         measuring blast radius/impact of changes to a Listener.
@@ -3462,7 +3587,7 @@ spec:
                     supportedKinds:
                       description: |-
                         SupportedKinds is the list indicating the Kinds supported by this
-                        listener. This MUST represent the kinds an implementation supports for
+                        listener. This MUST represent the kinds supported by an implementation for
                         that Listener configuration.
 
                         If kinds are specified in Spec that are not supported, they MUST NOT
@@ -3496,7 +3621,6 @@ spec:
                   - attachedRoutes
                   - conditions
                   - name
-                  - supportedKinds
                   type: object
                 maxItems: 64
                 type: array
@@ -3630,14 +3754,14 @@ spec:
               allowedListeners:
                 description: |-
                   AllowedListeners defines which ListenerSets can be attached to this Gateway.
-                  While this feature is experimental, the default value is to allow no ListenerSets.
+                  The default value is to allow no ListenerSets.
                 properties:
                   namespaces:
                     default:
                       from: None
                     description: |-
                       Namespaces defines which namespaces ListenerSets can be attached to this Gateway.
-                      While this feature is experimental, the default value is to allow no ListenerSets.
+                      The default value is to allow no ListenerSets.
                     properties:
                       from:
                         default: None
@@ -3650,7 +3774,7 @@ spec:
                           * All: ListenerSets in all namespaces may be attached to this Gateway.
                           * None: Only listeners defined in the Gateway's spec are allowed
 
-                          While this feature is experimental, the default value None
+                          The default value None
                         enum:
                         - All
                         - Selector
@@ -4199,7 +4323,7 @@ spec:
                           the Gateway SHOULD return a 421.
                         * If the current Listener (selected by SNI matching during ClientHello)
                           does not match the Host:
-                            * If another Listener does match the Host the Gateway SHOULD return a
+                            * If another Listener does match the Host, the Gateway SHOULD return a
                               421.
                             * If no other Listener matches the Host, the Gateway MUST return a
                               404.
@@ -4410,6 +4534,9 @@ spec:
                 - message: tls mode must be Terminate for protocol HTTPS
                   rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode
                     == '''' || l.tls.mode == ''Terminate'') : true)'
+                - message: tls mode must be set for protocol TLS
+                  rule: 'self.all(l, (l.protocol == ''TLS'' ? has(l.tls) && has(l.tls.mode)
+                    && l.tls.mode != '''' : true))'
                 - message: hostname must not be specified for protocols ['TCP', 'UDP']
                   rule: 'self.all(l, l.protocol in [''TCP'', ''UDP'']  ? (!has(l.hostname)
                     || l.hostname == '''') : true)'
@@ -4439,19 +4566,30 @@ spec:
                     properties:
                       clientCertificateRef:
                         description: |-
-                          ClientCertificateRef is a reference to an object that contains a Client
-                          Certificate and the associated private key.
+                          ClientCertificateRef references an object that contains a client certificate
+                          and its associated private key. It can reference standard Kubernetes resources,
+                          i.e., Secret, or implementation-specific custom resources.
 
-                          References to a resource in different namespace are invalid UNLESS there
-                          is a ReferenceGrant in the target namespace that allows the certificate
-                          to be attached. If a ReferenceGrant does not allow this reference, the
-                          "ResolvedRefs" condition MUST be set to False for this listener with the
-                          "RefNotPermitted" reason.
+                          A ClientCertificateRef is considered invalid if:
 
-                          ClientCertificateRef can reference to standard Kubernetes resources, i.e.
-                          Secret, or implementation-specific custom resources.
+                          * It refers to a resource that cannot be resolved (e.g., the referenced resource
+                            does not exist) or is misconfigured (e.g., a Secret does not contain the keys
+                            named `tls.crt` and `tls.key`). In this case, the `ResolvedRefs` condition
+                            on the Gateway MUST be set to False with the Reason `InvalidClientCertificateRef`
+                            and the Message of the Condition MUST indicate why the reference is invalid.
 
-                          Support: Core
+                          * It refers to a resource in another namespace UNLESS there is a ReferenceGrant
+                            in the target namespace that allows the certificate to be attached.
+                            If a ReferenceGrant does not allow this reference, the `ResolvedRefs` condition
+                            on the Gateway MUST be set to False with the Reason `RefNotPermitted`.
+
+                          Implementations MAY choose to perform further validation of the certificate
+                          content (e.g., checking expiry or enforcing specific formats). In such cases,
+                          an implementation-specific Reason and Message MUST be set.
+
+                          Support: Core - Reference to a Kubernetes TLS Secret (with the type `kubernetes.io/tls`).
+                          Support: Implementation-specific - Other resource kinds or Secrets with a
+                          different type (e.g., `Opaque`).
                         properties:
                           group:
                             default: ""
@@ -4518,27 +4656,49 @@ spec:
                             properties:
                               caCertificateRefs:
                                 description: |-
-                                  CACertificateRefs contains one or more references to
-                                  Kubernetes objects that contain TLS certificates of
-                                  the Certificate Authorities that can be used
-                                  as a trust anchor to validate the certificates presented by the client.
+                                  CACertificateRefs contains one or more references to Kubernetes
+                                  objects that contain a PEM-encoded TLS CA certificate bundle, which
+                                  is used as a trust anchor to validate the certificates presented by
+                                  the client.
 
-                                  A single CA certificate reference to a Kubernetes ConfigMap
-                                  has "Core" support.
-                                  Implementations MAY choose to support attaching multiple CA certificates to
-                                  a Listener, but this behavior is implementation-specific.
+                                  A CACertificateRef is invalid if:
 
-                                  Support: Core - A single reference to a Kubernetes ConfigMap
-                                  with the CA certificate in a key named `ca.crt`.
+                                  * It refers to a resource that cannot be resolved (e.g., the
+                                    referenced resource does not exist) or is misconfigured (e.g., a
+                                    ConfigMap does not contain a key named `ca.crt`). In this case, the
+                                    Reason on all matching HTTPS listeners must be set to `InvalidCACertificateRef`
+                                    and the Message of the Condition must indicate which reference is invalid and why.
 
-                                  Support: Implementation-specific (More than one certificate in a ConfigMap
-                                  with different keys or more than one reference, or other kinds of resources).
+                                  * It refers to an unknown or unsupported kind of resource. In this
+                                    case, the Reason on all matching HTTPS listeners must be set to
+                                    `InvalidCACertificateKind` and the Message of the Condition must explain
+                                    which kind of resource is unknown or unsupported.
 
-                                  References to a resource in a different namespace are invalid UNLESS there
-                                  is a ReferenceGrant in the target namespace that allows the certificate
-                                  to be attached. If a ReferenceGrant does not allow this reference, the
-                                  "ResolvedRefs" condition MUST be set to False for this listener with the
-                                  "RefNotPermitted" reason.
+                                  * It refers to a resource in another namespace UNLESS there is a
+                                    ReferenceGrant in the target namespace that allows the CA
+                                    certificate to be attached. If a ReferenceGrant does not allow this
+                                    reference, the `ResolvedRefs` on all matching HTTPS listeners condition
+                                    MUST be set with the Reason `RefNotPermitted`.
+
+                                  Implementations MAY choose to perform further validation of the
+                                  certificate content (e.g., checking expiry or enforcing specific formats).
+                                  In such cases, an implementation-specific Reason and Message MUST be set.
+
+                                  In all cases, the implementation MUST ensure that the `ResolvedRefs`
+                                  condition is set to `status: False` on all targeted listeners (i.e.,
+                                  listeners serving HTTPS on a matching port). The condition MUST
+                                  include a Reason and Message that indicate the cause of the error. If
+                                  ALL CACertificateRefs are invalid, the implementation MUST also ensure
+                                  the `Accepted` condition on the listener is set to `status: False`, with
+                                  the Reason `NoValidCACertificate`.
+                                  Implementations MAY choose to support attaching multiple CA certificates
+                                  to a listener, but this behavior is implementation-specific.
+
+                                  Support: Core - A single reference to a Kubernetes ConfigMap, with the
+                                  CA certificate in a key named `ca.crt`.
+
+                                  Support: Implementation-specific - More than one reference, other kinds
+                                  of resources, or a single reference that includes multiple certificates.
                                 items:
                                   description: |-
                                     ObjectReference identifies an API object including its namespace.
@@ -4661,27 +4821,49 @@ spec:
                                   properties:
                                     caCertificateRefs:
                                       description: |-
-                                        CACertificateRefs contains one or more references to
-                                        Kubernetes objects that contain TLS certificates of
-                                        the Certificate Authorities that can be used
-                                        as a trust anchor to validate the certificates presented by the client.
+                                        CACertificateRefs contains one or more references to Kubernetes
+                                        objects that contain a PEM-encoded TLS CA certificate bundle, which
+                                        is used as a trust anchor to validate the certificates presented by
+                                        the client.
 
-                                        A single CA certificate reference to a Kubernetes ConfigMap
-                                        has "Core" support.
-                                        Implementations MAY choose to support attaching multiple CA certificates to
-                                        a Listener, but this behavior is implementation-specific.
+                                        A CACertificateRef is invalid if:
 
-                                        Support: Core - A single reference to a Kubernetes ConfigMap
-                                        with the CA certificate in a key named `ca.crt`.
+                                        * It refers to a resource that cannot be resolved (e.g., the
+                                          referenced resource does not exist) or is misconfigured (e.g., a
+                                          ConfigMap does not contain a key named `ca.crt`). In this case, the
+                                          Reason on all matching HTTPS listeners must be set to `InvalidCACertificateRef`
+                                          and the Message of the Condition must indicate which reference is invalid and why.
 
-                                        Support: Implementation-specific (More than one certificate in a ConfigMap
-                                        with different keys or more than one reference, or other kinds of resources).
+                                        * It refers to an unknown or unsupported kind of resource. In this
+                                          case, the Reason on all matching HTTPS listeners must be set to
+                                          `InvalidCACertificateKind` and the Message of the Condition must explain
+                                          which kind of resource is unknown or unsupported.
 
-                                        References to a resource in a different namespace are invalid UNLESS there
-                                        is a ReferenceGrant in the target namespace that allows the certificate
-                                        to be attached. If a ReferenceGrant does not allow this reference, the
-                                        "ResolvedRefs" condition MUST be set to False for this listener with the
-                                        "RefNotPermitted" reason.
+                                        * It refers to a resource in another namespace UNLESS there is a
+                                          ReferenceGrant in the target namespace that allows the CA
+                                          certificate to be attached. If a ReferenceGrant does not allow this
+                                          reference, the `ResolvedRefs` on all matching HTTPS listeners condition
+                                          MUST be set with the Reason `RefNotPermitted`.
+
+                                        Implementations MAY choose to perform further validation of the
+                                        certificate content (e.g., checking expiry or enforcing specific formats).
+                                        In such cases, an implementation-specific Reason and Message MUST be set.
+
+                                        In all cases, the implementation MUST ensure that the `ResolvedRefs`
+                                        condition is set to `status: False` on all targeted listeners (i.e.,
+                                        listeners serving HTTPS on a matching port). The condition MUST
+                                        include a Reason and Message that indicate the cause of the error. If
+                                        ALL CACertificateRefs are invalid, the implementation MUST also ensure
+                                        the `Accepted` condition on the listener is set to `status: False`, with
+                                        the Reason `NoValidCACertificate`.
+                                        Implementations MAY choose to support attaching multiple CA certificates
+                                        to a listener, but this behavior is implementation-specific.
+
+                                        Support: Core - A single reference to a Kubernetes ConfigMap, with the
+                                        CA certificate in a key named `ca.crt`.
+
+                                        Support: Implementation-specific - More than one reference, other kinds
+                                        of resources, or a single reference that includes multiple certificates.
                                       items:
                                         description: |-
                                           ObjectReference identifies an API object including its namespace.
@@ -4855,6 +5037,20 @@ spec:
                 maxItems: 16
                 type: array
                 x-kubernetes-list-type: atomic
+              attachedListenerSets:
+                description: |-
+                  AttachedListenerSets represents the total number of ListenerSets that have been
+                  successfully attached to this Gateway.
+
+                  A ListenerSet is successfully attached to a Gateway when all the following conditions are met:
+                  - The ListenerSet is selected by the Gateway's AllowedListeners field
+                  - The ListenerSet has a valid ParentRef selecting the Gateway
+                  - The ListenerSet's status has the condition "Accepted: true"
+
+                  Uses for this field include troubleshooting AttachedListenerSets attachment and
+                  measuring blast radius/impact of changes to a Gateway.
+                format: int32
+                type: integer
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"
@@ -4959,8 +5155,11 @@ spec:
                         attachment semantics can be found in the documentation on the various
                         Route kinds ParentRefs fields). Listener or Route status does not impact
                         successful attachment, i.e. the AttachedRoutes field count MUST be set
-                        for Listeners with condition Accepted: false and MUST count successfully
-                        attached Routes that may themselves have Accepted: false conditions.
+                        for Listeners, even if the Accepted condition of an individual Listener is set
+                        to "False". The AttachedRoutes number represents the number of Routes with
+                        the Accepted condition set to "True" that have been attached to this Listener.
+                        Routes with any other value for the Accepted condition MUST NOT be included
+                        in this count.
 
                         Uses for this field include troubleshooting Route attachment and
                         measuring blast radius/impact of changes to a Listener.
@@ -5039,7 +5238,7 @@ spec:
                     supportedKinds:
                       description: |-
                         SupportedKinds is the list indicating the Kinds supported by this
-                        listener. This MUST represent the kinds an implementation supports for
+                        listener. This MUST represent the kinds supported by an implementation for
                         that Listener configuration.
 
                         If kinds are specified in Spec that are not supported, they MUST NOT
@@ -5073,7 +5272,6 @@ spec:
                   - attachedRoutes
                   - conditions
                   - name
-                  - supportedKinds
                   type: object
                 maxItems: 64
                 type: array
@@ -5102,8 +5300,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.1
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.0
     gateway.networking.k8s.io/channel: experimental
   name: grpcroutes.gateway.networking.k8s.io
 spec:
@@ -5645,10 +5843,14 @@ spec:
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
-                                            description: Value is the value of HTTP
-                                              Header to be matched.
+                                            description: |-
+                                              Value is the value of HTTP Header to be matched.
+
+                                              Must consist of printable US-ASCII characters, optionally separated
+                                              by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
                                             maxLength: 4096
                                             minLength: 1
+                                            pattern: ^[!-~]+([\t ]?[!-~]+)*$
                                             type: string
                                         required:
                                         - name
@@ -5720,10 +5922,14 @@ spec:
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
-                                            description: Value is the value of HTTP
-                                              Header to be matched.
+                                            description: |-
+                                              Value is the value of HTTP Header to be matched.
+
+                                              Must consist of printable US-ASCII characters, optionally separated
+                                              by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
                                             maxLength: 4096
                                             minLength: 1
+                                            pattern: ^[!-~]+([\t ]?[!-~]+)*$
                                             type: string
                                         required:
                                         - name
@@ -5928,10 +6134,14 @@ spec:
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
-                                            description: Value is the value of HTTP
-                                              Header to be matched.
+                                            description: |-
+                                              Value is the value of HTTP Header to be matched.
+
+                                              Must consist of printable US-ASCII characters, optionally separated
+                                              by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
                                             maxLength: 4096
                                             minLength: 1
+                                            pattern: ^[!-~]+([\t ]?[!-~]+)*$
                                             type: string
                                         required:
                                         - name
@@ -6003,10 +6213,14 @@ spec:
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
-                                            description: Value is the value of HTTP
-                                              Header to be matched.
+                                            description: |-
+                                              Value is the value of HTTP Header to be matched.
+
+                                              Must consist of printable US-ASCII characters, optionally separated
+                                              by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
                                             maxLength: 4096
                                             minLength: 1
+                                            pattern: ^[!-~]+([\t ]?[!-~]+)*$
                                             type: string
                                         required:
                                         - name
@@ -6297,10 +6511,14 @@ spec:
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: |-
+                                        Value is the value of HTTP Header to be matched.
+
+                                        Must consist of printable US-ASCII characters, optionally separated
+                                        by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
                                       maxLength: 4096
                                       minLength: 1
+                                      pattern: ^[!-~]+([\t ]?[!-~]+)*$
                                       type: string
                                   required:
                                   - name
@@ -6371,10 +6589,14 @@ spec:
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: |-
+                                        Value is the value of HTTP Header to be matched.
+
+                                        Must consist of printable US-ASCII characters, optionally separated
+                                        by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
                                       maxLength: 4096
                                       minLength: 1
+                                      pattern: ^[!-~]+([\t ]?[!-~]+)*$
                                       type: string
                                   required:
                                   - name
@@ -6578,10 +6800,14 @@ spec:
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: |-
+                                        Value is the value of HTTP Header to be matched.
+
+                                        Must consist of printable US-ASCII characters, optionally separated
+                                        by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
                                       maxLength: 4096
                                       minLength: 1
+                                      pattern: ^[!-~]+([\t ]?[!-~]+)*$
                                       type: string
                                   required:
                                   - name
@@ -6652,10 +6878,14 @@ spec:
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: |-
+                                        Value is the value of HTTP Header to be matched.
+
+                                        Must consist of printable US-ASCII characters, optionally separated
+                                        by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
                                       maxLength: 4096
                                       minLength: 1
+                                      pattern: ^[!-~]+([\t ]?[!-~]+)*$
                                       type: string
                                   required:
                                   - name
@@ -6806,8 +7036,8 @@ spec:
                             - method:
                               type: Exact
                               service: "foo"
-                              headers:
-                            - name: "version"
+                            - headers:
+                              name: "version"
                               value "v1"
 
                           ```
@@ -6994,7 +7224,7 @@ spec:
                           default: Cookie
                           description: |-
                             Type defines the type of session persistence such as through
-                            the use a header or cookie. Defaults to cookie based session
+                            the use of a header or cookie. Defaults to cookie based session
                             persistence.
 
                             Support: Core for "Cookie" type
@@ -7010,6 +7240,8 @@ spec:
                           is Permanent
                         rule: '!has(self.cookieConfig) || !has(self.cookieConfig.lifetimeType)
                           || self.cookieConfig.lifetimeType != ''Permanent'' || has(self.absoluteTimeout)'
+                      - message: cookieConfig can only be set with type Cookie
+                        rule: '!has(self.cookieConfig) || self.type == ''Cookie'''
                   type: object
                 maxItems: 16
                 type: array
@@ -7101,7 +7333,7 @@ spec:
 
                         * The Route refers to a nonexistent parent.
                         * The Route is of a type that the controller does not support.
-                        * The Route is in a namespace the controller does not have access to.
+                        * The Route is in a namespace to which the controller does not have access.
                       items:
                         description: Condition contains details for one aspect of
                           the current state of this API Resource.
@@ -7351,8 +7583,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.1
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.0
     gateway.networking.k8s.io/channel: experimental
   name: httproutes.gateway.networking.k8s.io
 spec:
@@ -7832,7 +8064,7 @@ spec:
                                         AllowHeaders indicates which HTTP request headers are supported for
                                         accessing the requested resource.
 
-                                        Header names are not case sensitive.
+                                        Header names are not case-sensitive.
 
                                         Multiple header names in the value of the `Access-Control-Allow-Headers`
                                         response header are separated by a comma (",").
@@ -7851,18 +8083,21 @@ spec:
                                         client side.
 
                                         A wildcard indicates that the requests with all HTTP headers are allowed.
-                                        The `Access-Control-Allow-Headers` response header can only use `*`
-                                        wildcard as value when the `AllowCredentials` field is false or omitted.
+                                        If config contains the wildcard "*" in allowHeaders and the request is
+                                        not credentialed, the `Access-Control-Allow-Headers` response header
+                                        can either use the `*` wildcard or the value of
+                                        Access-Control-Request-Headers from the request.
 
-                                        When the `AllowCredentials` field is true and `AllowHeaders` field
-                                        specified with the `*` wildcard, the gateway must specify one or more
+                                        When the request is credentialed, the gateway must not specify the `*`
+                                        wildcard in the `Access-Control-Allow-Headers` response header. When
+                                        also the `AllowCredentials` field is true and `AllowHeaders` field
+                                        is specified with the `*` wildcard, the gateway must specify one or more
                                         HTTP headers in the value of the `Access-Control-Allow-Headers` response
                                         header. The value of the header `Access-Control-Allow-Headers` is same as
                                         the `Access-Control-Request-Headers` header provided by the client. If
                                         the header `Access-Control-Request-Headers` is not included in the
                                         request, the gateway will omit the `Access-Control-Allow-Headers`
-                                        response header, instead of specifying the `*` wildcard. A Gateway
-                                        implementation may choose to add implementation-specific default headers.
+                                        response header, instead of specifying the `*` wildcard.
 
                                         Support: Extended
                                       items:
@@ -7886,6 +8121,10 @@ spec:
                                       maxItems: 64
                                       type: array
                                       x-kubernetes-list-type: set
+                                      x-kubernetes-validations:
+                                      - message: AllowHeaders cannot contain '*' alongside
+                                          other methods
+                                        rule: '!(''*'' in self && self.size() > 1)'
                                     allowMethods:
                                       description: |-
                                         AllowMethods indicates which HTTP methods are supported for accessing the
@@ -7894,7 +8133,7 @@ spec:
                                         Valid values are any method defined by RFC9110, along with the special
                                         value `*`, which represents all HTTP methods are allowed.
 
-                                        Method names are case sensitive, so these values are also case-sensitive.
+                                        Method names are case-sensitive, so these values are also case-sensitive.
                                         (See https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1)
 
                                         Multiple method names in the value of the `Access-Control-Allow-Methods`
@@ -7914,18 +8153,21 @@ spec:
                                         `Access-Control-Allow-Methods`, it will present an error on the client
                                         side.
 
-                                        The `Access-Control-Allow-Methods` response header can only use `*`
-                                        wildcard as value when the `AllowCredentials` field is false or omitted.
+                                        If config contains the wildcard "*" in allowMethods and the request is
+                                        not credentialed, the `Access-Control-Allow-Methods` response header
+                                        can either use the `*` wildcard or the value of
+                                        Access-Control-Request-Method from the request.
 
-                                        When the `AllowCredentials` field is true and `AllowMethods` field
+                                        When the request is credentialed, the gateway must not specify the `*`
+                                        wildcard in the `Access-Control-Allow-Methods` response header. When
+                                        also the `AllowCredentials` field is true and `AllowMethods` field
                                         specified with the `*` wildcard, the gateway must specify one HTTP method
                                         in the value of the Access-Control-Allow-Methods response header. The
                                         value of the header `Access-Control-Allow-Methods` is same as the
                                         `Access-Control-Request-Method` header provided by the client. If the
                                         header `Access-Control-Request-Method` is not included in the request,
                                         the gateway will omit the `Access-Control-Allow-Methods` response header,
-                                        instead of specifying the `*` wildcard. A Gateway implementation may
-                                        choose to add implementation-specific default methods.
+                                        instead of specifying the `*` wildcard.
 
                                         Support: Extended
                                       items:
@@ -7992,10 +8234,19 @@ spec:
                                         the CORS headers. The cross-origin request fails on the client side.
                                         Therefore, the client doesn't attempt the actual cross-origin request.
 
-                                        The `Access-Control-Allow-Origin` response header can only use `*`
-                                        wildcard as value when the `AllowCredentials` field is false or omitted.
+                                        Conversely, if the request `Origin` matches one of the configured
+                                        allowed origins, the gateway sets the response header
+                                        `Access-Control-Allow-Origin` to the same value as the `Origin`
+                                        header provided by the client.
 
-                                        When the `AllowCredentials` field is true and `AllowOrigins` field
+                                        When config has the wildcard ("*") in allowOrigins, and the request
+                                        is not credentialed (e.g., it is a preflight request), the
+                                        `Access-Control-Allow-Origin` response header either contains the
+                                        wildcard as well or the Origin from the request.
+
+                                        When the request is credentialed, the gateway must not specify the `*`
+                                        wildcard in the `Access-Control-Allow-Origin` response header. When
+                                        also the `AllowCredentials` field is true and `AllowOrigins` field
                                         specified with the `*` wildcard, the gateway must return a single origin
                                         in the value of the `Access-Control-Allow-Origin` response header,
                                         instead of specifying the `*` wildcard. The value of the header
@@ -8007,12 +8258,12 @@ spec:
                                         description: |-
                                           The CORSOrigin MUST NOT be a relative URI, and it MUST follow the URI syntax and
                                           encoding rules specified in RFC3986.  The CORSOrigin MUST include both a
-                                          scheme (e.g., "http" or "spiffe") and a scheme-specific-part, or it should be a single '*' character.
+                                          scheme ("http" or "https") and a scheme-specific-part, or it should be a single '*' character.
                                           URIs that include an authority MUST include a fully qualified domain name or
                                           IP address as the host.
                                         maxLength: 253
                                         minLength: 1
-                                        pattern: (^\*$)|(^([a-zA-Z][a-zA-Z0-9+\-.]+):\/\/([^:/?#]+)(:([0-9]{1,5}))?$)
+                                        pattern: (^\*$)|(^(http(s)?):\/\/(((\*\.)?([a-zA-Z0-9\-]+\.)*[a-zA-Z0-9-]+|\*)(:([0-9]{1,5}))?)$)
                                         type: string
                                       maxItems: 64
                                       type: array
@@ -8043,14 +8294,18 @@ spec:
                                         this additional header will be exposed as part of the response to the
                                         client.
 
-                                        Header names are not case sensitive.
+                                        Header names are not case-sensitive.
 
                                         Multiple header names in the value of the `Access-Control-Expose-Headers`
                                         response header are separated by a comma (",").
 
                                         A wildcard indicates that the responses with all HTTP headers are exposed
                                         to clients. The `Access-Control-Expose-Headers` response header can only
-                                        use `*` wildcard as value when the `AllowCredentials` field is false or omitted.
+                                        use `*` wildcard as value when the request is not credentialed.
+
+                                        When the `exposeHeaders` config field contains the "*" wildcard and
+                                        the request is credentialed, the gateway cannot use the `*` wildcard in
+                                        the `Access-Control-Expose-Headers` response header.
 
                                         Support: Extended
                                       items:
@@ -8086,6 +8341,9 @@ spec:
 
                                         The default value of `Access-Control-Max-Age` response header is 5
                                         (seconds).
+
+                                        When the `MaxAge` field is unspecified, the gateway sets the response
+                                        header "Access-Control-Max-Age: 5" by default.
                                       format: int32
                                       minimum: 1
                                       type: integer
@@ -8264,6 +8522,7 @@ spec:
                                             If the list has entries, only those entries must be sent.
                                           items:
                                             type: string
+                                          maxItems: 64
                                           type: array
                                           x-kubernetes-list-type: set
                                       type: object
@@ -8302,6 +8561,7 @@ spec:
                                             request must be set to the actual number of bytes forwarded.
                                           items:
                                             type: string
+                                          maxItems: 64
                                           type: array
                                           x-kubernetes-list-type: set
                                         allowedResponseHeaders:
@@ -8313,6 +8573,7 @@ spec:
                                             except Authority or Host must be copied.
                                           items:
                                             type: string
+                                          maxItems: 64
                                           type: array
                                           x-kubernetes-list-type: set
                                         path:
@@ -8417,10 +8678,14 @@ spec:
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
-                                            description: Value is the value of HTTP
-                                              Header to be matched.
+                                            description: |-
+                                              Value is the value of HTTP Header to be matched.
+
+                                              Must consist of printable US-ASCII characters, optionally separated
+                                              by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
                                             maxLength: 4096
                                             minLength: 1
+                                            pattern: ^[!-~]+([\t ]?[!-~]+)*$
                                             type: string
                                         required:
                                         - name
@@ -8492,10 +8757,14 @@ spec:
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
-                                            description: Value is the value of HTTP
-                                              Header to be matched.
+                                            description: |-
+                                              Value is the value of HTTP Header to be matched.
+
+                                              Must consist of printable US-ASCII characters, optionally separated
+                                              by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
                                             maxLength: 4096
                                             minLength: 1
+                                            pattern: ^[!-~]+([\t ]?[!-~]+)*$
                                             type: string
                                         required:
                                         - name
@@ -8806,6 +9075,9 @@ spec:
                                       enum:
                                       - 301
                                       - 302
+                                      - 303
+                                      - 307
+                                      - 308
                                       type: integer
                                   type: object
                                 responseHeaderModifier:
@@ -8853,10 +9125,14 @@ spec:
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
-                                            description: Value is the value of HTTP
-                                              Header to be matched.
+                                            description: |-
+                                              Value is the value of HTTP Header to be matched.
+
+                                              Must consist of printable US-ASCII characters, optionally separated
+                                              by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
                                             maxLength: 4096
                                             minLength: 1
+                                            pattern: ^[!-~]+([\t ]?[!-~]+)*$
                                             type: string
                                         required:
                                         - name
@@ -8928,10 +9204,14 @@ spec:
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
-                                            description: Value is the value of HTTP
-                                              Header to be matched.
+                                            description: |-
+                                              Value is the value of HTTP Header to be matched.
+
+                                              Must consist of printable US-ASCII characters, optionally separated
+                                              by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
                                             maxLength: 4096
                                             minLength: 1
+                                            pattern: ^[!-~]+([\t ]?[!-~]+)*$
                                             type: string
                                         required:
                                         - name
@@ -9075,6 +9355,11 @@ spec:
                               - type
                               type: object
                               x-kubernetes-validations:
+                              - message: filter.cors must be nil if the filter.type
+                                  is not CORS
+                                rule: '!(has(self.cors) && self.type != ''CORS'')'
+                              - message: filter.cors must be specified for CORS filter.type
+                                rule: '!(!has(self.cors) && self.type == ''CORS'')'
                               - message: filter.requestHeaderModifier must be nil
                                   if the filter.type is not RequestHeaderModifier
                                 rule: '!(has(self.requestHeaderModifier) && self.type
@@ -9118,11 +9403,6 @@ spec:
                               - message: filter.extensionRef must be specified for
                                   ExtensionRef filter.type
                                 rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
-                              - message: filter.cors must be nil if the filter.type
-                                  is not CORS
-                                rule: '!(has(self.cors) && self.type != ''CORS'')'
-                              - message: filter.cors must be specified for CORS filter.type
-                                rule: '!(!has(self.cors) && self.type == ''CORS'')'
                               - message: filter.externalAuth must be nil if the filter.type
                                   is not ExternalAuth
                                 rule: '!(has(self.externalAuth) && self.type != ''ExternalAuth'')'
@@ -9312,7 +9592,7 @@ spec:
                                   AllowHeaders indicates which HTTP request headers are supported for
                                   accessing the requested resource.
 
-                                  Header names are not case sensitive.
+                                  Header names are not case-sensitive.
 
                                   Multiple header names in the value of the `Access-Control-Allow-Headers`
                                   response header are separated by a comma (",").
@@ -9331,18 +9611,21 @@ spec:
                                   client side.
 
                                   A wildcard indicates that the requests with all HTTP headers are allowed.
-                                  The `Access-Control-Allow-Headers` response header can only use `*`
-                                  wildcard as value when the `AllowCredentials` field is false or omitted.
+                                  If config contains the wildcard "*" in allowHeaders and the request is
+                                  not credentialed, the `Access-Control-Allow-Headers` response header
+                                  can either use the `*` wildcard or the value of
+                                  Access-Control-Request-Headers from the request.
 
-                                  When the `AllowCredentials` field is true and `AllowHeaders` field
-                                  specified with the `*` wildcard, the gateway must specify one or more
+                                  When the request is credentialed, the gateway must not specify the `*`
+                                  wildcard in the `Access-Control-Allow-Headers` response header. When
+                                  also the `AllowCredentials` field is true and `AllowHeaders` field
+                                  is specified with the `*` wildcard, the gateway must specify one or more
                                   HTTP headers in the value of the `Access-Control-Allow-Headers` response
                                   header. The value of the header `Access-Control-Allow-Headers` is same as
                                   the `Access-Control-Request-Headers` header provided by the client. If
                                   the header `Access-Control-Request-Headers` is not included in the
                                   request, the gateway will omit the `Access-Control-Allow-Headers`
-                                  response header, instead of specifying the `*` wildcard. A Gateway
-                                  implementation may choose to add implementation-specific default headers.
+                                  response header, instead of specifying the `*` wildcard.
 
                                   Support: Extended
                                 items:
@@ -9366,6 +9649,10 @@ spec:
                                 maxItems: 64
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: AllowHeaders cannot contain '*' alongside
+                                    other methods
+                                  rule: '!(''*'' in self && self.size() > 1)'
                               allowMethods:
                                 description: |-
                                   AllowMethods indicates which HTTP methods are supported for accessing the
@@ -9374,7 +9661,7 @@ spec:
                                   Valid values are any method defined by RFC9110, along with the special
                                   value `*`, which represents all HTTP methods are allowed.
 
-                                  Method names are case sensitive, so these values are also case-sensitive.
+                                  Method names are case-sensitive, so these values are also case-sensitive.
                                   (See https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1)
 
                                   Multiple method names in the value of the `Access-Control-Allow-Methods`
@@ -9394,18 +9681,21 @@ spec:
                                   `Access-Control-Allow-Methods`, it will present an error on the client
                                   side.
 
-                                  The `Access-Control-Allow-Methods` response header can only use `*`
-                                  wildcard as value when the `AllowCredentials` field is false or omitted.
+                                  If config contains the wildcard "*" in allowMethods and the request is
+                                  not credentialed, the `Access-Control-Allow-Methods` response header
+                                  can either use the `*` wildcard or the value of
+                                  Access-Control-Request-Method from the request.
 
-                                  When the `AllowCredentials` field is true and `AllowMethods` field
+                                  When the request is credentialed, the gateway must not specify the `*`
+                                  wildcard in the `Access-Control-Allow-Methods` response header. When
+                                  also the `AllowCredentials` field is true and `AllowMethods` field
                                   specified with the `*` wildcard, the gateway must specify one HTTP method
                                   in the value of the Access-Control-Allow-Methods response header. The
                                   value of the header `Access-Control-Allow-Methods` is same as the
                                   `Access-Control-Request-Method` header provided by the client. If the
                                   header `Access-Control-Request-Method` is not included in the request,
                                   the gateway will omit the `Access-Control-Allow-Methods` response header,
-                                  instead of specifying the `*` wildcard. A Gateway implementation may
-                                  choose to add implementation-specific default methods.
+                                  instead of specifying the `*` wildcard.
 
                                   Support: Extended
                                 items:
@@ -9472,10 +9762,19 @@ spec:
                                   the CORS headers. The cross-origin request fails on the client side.
                                   Therefore, the client doesn't attempt the actual cross-origin request.
 
-                                  The `Access-Control-Allow-Origin` response header can only use `*`
-                                  wildcard as value when the `AllowCredentials` field is false or omitted.
+                                  Conversely, if the request `Origin` matches one of the configured
+                                  allowed origins, the gateway sets the response header
+                                  `Access-Control-Allow-Origin` to the same value as the `Origin`
+                                  header provided by the client.
 
-                                  When the `AllowCredentials` field is true and `AllowOrigins` field
+                                  When config has the wildcard ("*") in allowOrigins, and the request
+                                  is not credentialed (e.g., it is a preflight request), the
+                                  `Access-Control-Allow-Origin` response header either contains the
+                                  wildcard as well or the Origin from the request.
+
+                                  When the request is credentialed, the gateway must not specify the `*`
+                                  wildcard in the `Access-Control-Allow-Origin` response header. When
+                                  also the `AllowCredentials` field is true and `AllowOrigins` field
                                   specified with the `*` wildcard, the gateway must return a single origin
                                   in the value of the `Access-Control-Allow-Origin` response header,
                                   instead of specifying the `*` wildcard. The value of the header
@@ -9487,12 +9786,12 @@ spec:
                                   description: |-
                                     The CORSOrigin MUST NOT be a relative URI, and it MUST follow the URI syntax and
                                     encoding rules specified in RFC3986.  The CORSOrigin MUST include both a
-                                    scheme (e.g., "http" or "spiffe") and a scheme-specific-part, or it should be a single '*' character.
+                                    scheme ("http" or "https") and a scheme-specific-part, or it should be a single '*' character.
                                     URIs that include an authority MUST include a fully qualified domain name or
                                     IP address as the host.
                                   maxLength: 253
                                   minLength: 1
-                                  pattern: (^\*$)|(^([a-zA-Z][a-zA-Z0-9+\-.]+):\/\/([^:/?#]+)(:([0-9]{1,5}))?$)
+                                  pattern: (^\*$)|(^(http(s)?):\/\/(((\*\.)?([a-zA-Z0-9\-]+\.)*[a-zA-Z0-9-]+|\*)(:([0-9]{1,5}))?)$)
                                   type: string
                                 maxItems: 64
                                 type: array
@@ -9523,14 +9822,18 @@ spec:
                                   this additional header will be exposed as part of the response to the
                                   client.
 
-                                  Header names are not case sensitive.
+                                  Header names are not case-sensitive.
 
                                   Multiple header names in the value of the `Access-Control-Expose-Headers`
                                   response header are separated by a comma (",").
 
                                   A wildcard indicates that the responses with all HTTP headers are exposed
                                   to clients. The `Access-Control-Expose-Headers` response header can only
-                                  use `*` wildcard as value when the `AllowCredentials` field is false or omitted.
+                                  use `*` wildcard as value when the request is not credentialed.
+
+                                  When the `exposeHeaders` config field contains the "*" wildcard and
+                                  the request is credentialed, the gateway cannot use the `*` wildcard in
+                                  the `Access-Control-Expose-Headers` response header.
 
                                   Support: Extended
                                 items:
@@ -9566,6 +9869,9 @@ spec:
 
                                   The default value of `Access-Control-Max-Age` response header is 5
                                   (seconds).
+
+                                  When the `MaxAge` field is unspecified, the gateway sets the response
+                                  header "Access-Control-Max-Age: 5" by default.
                                 format: int32
                                 minimum: 1
                                 type: integer
@@ -9744,6 +10050,7 @@ spec:
                                       If the list has entries, only those entries must be sent.
                                     items:
                                       type: string
+                                    maxItems: 64
                                     type: array
                                     x-kubernetes-list-type: set
                                 type: object
@@ -9782,6 +10089,7 @@ spec:
                                       request must be set to the actual number of bytes forwarded.
                                     items:
                                       type: string
+                                    maxItems: 64
                                     type: array
                                     x-kubernetes-list-type: set
                                   allowedResponseHeaders:
@@ -9793,6 +10101,7 @@ spec:
                                       except Authority or Host must be copied.
                                     items:
                                       type: string
+                                    maxItems: 64
                                     type: array
                                     x-kubernetes-list-type: set
                                   path:
@@ -9894,10 +10203,14 @@ spec:
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: |-
+                                        Value is the value of HTTP Header to be matched.
+
+                                        Must consist of printable US-ASCII characters, optionally separated
+                                        by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
                                       maxLength: 4096
                                       minLength: 1
+                                      pattern: ^[!-~]+([\t ]?[!-~]+)*$
                                       type: string
                                   required:
                                   - name
@@ -9968,10 +10281,14 @@ spec:
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: |-
+                                        Value is the value of HTTP Header to be matched.
+
+                                        Must consist of printable US-ASCII characters, optionally separated
+                                        by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
                                       maxLength: 4096
                                       minLength: 1
+                                      pattern: ^[!-~]+([\t ]?[!-~]+)*$
                                       type: string
                                   required:
                                   - name
@@ -10282,6 +10599,9 @@ spec:
                                 enum:
                                 - 301
                                 - 302
+                                - 303
+                                - 307
+                                - 308
                                 type: integer
                             type: object
                           responseHeaderModifier:
@@ -10328,10 +10648,14 @@ spec:
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: |-
+                                        Value is the value of HTTP Header to be matched.
+
+                                        Must consist of printable US-ASCII characters, optionally separated
+                                        by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
                                       maxLength: 4096
                                       minLength: 1
+                                      pattern: ^[!-~]+([\t ]?[!-~]+)*$
                                       type: string
                                   required:
                                   - name
@@ -10402,10 +10726,14 @@ spec:
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: |-
+                                        Value is the value of HTTP Header to be matched.
+
+                                        Must consist of printable US-ASCII characters, optionally separated
+                                        by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
                                       maxLength: 4096
                                       minLength: 1
+                                      pattern: ^[!-~]+([\t ]?[!-~]+)*$
                                       type: string
                                   required:
                                   - name
@@ -10549,6 +10877,11 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
+                        - message: filter.cors must be nil if the filter.type is not
+                            CORS
+                          rule: '!(has(self.cors) && self.type != ''CORS'')'
+                        - message: filter.cors must be specified for CORS filter.type
+                          rule: '!(!has(self.cors) && self.type == ''CORS'')'
                         - message: filter.requestHeaderModifier must be nil if the
                             filter.type is not RequestHeaderModifier
                           rule: '!(has(self.requestHeaderModifier) && self.type !=
@@ -10589,11 +10922,6 @@ spec:
                         - message: filter.extensionRef must be specified for ExtensionRef
                             filter.type
                           rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
-                        - message: filter.cors must be nil if the filter.type is not
-                            CORS
-                          rule: '!(has(self.cors) && self.type != ''CORS'')'
-                        - message: filter.cors must be specified for CORS filter.type
-                          rule: '!(!has(self.cors) && self.type == ''CORS'')'
                         - message: filter.externalAuth must be nil if the filter.type
                             is not ExternalAuth
                           rule: '!(has(self.externalAuth) && self.type != ''ExternalAuth'')'
@@ -10739,10 +11067,14 @@ spec:
                                   - RegularExpression
                                   type: string
                                 value:
-                                  description: Value is the value of HTTP Header to
-                                    be matched.
+                                  description: |-
+                                    Value is the value of HTTP Header to be matched.
+
+                                    Must consist of printable US-ASCII characters, optionally separated
+                                    by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
                                   maxLength: 4096
                                   minLength: 1
+                                  pattern: ^[!-~]+([\t ]?[!-~]+)*$
                                   type: string
                               required:
                               - name
@@ -10951,7 +11283,7 @@ spec:
                             For example, setting the `rules[].retry.backoff` field to the value
                             `100ms` will cause a backend request to first be retried approximately
                             100 milliseconds after timing out or receiving a response code configured
-                            to be retryable.
+                            to be retriable.
 
                             An implementation MAY use an exponential or alternative backoff strategy
                             for subsequent retry attempts, MAY cap the maximum backoff duration to
@@ -10994,7 +11326,7 @@ spec:
                               HTTPRouteRetryStatusCode defines an HTTP response status code for
                               which a backend request should be retried.
 
-                              Implementations MUST support the following status codes as retryable:
+                              Implementations MUST support the following status codes as retriable:
 
                               * 500
                               * 502
@@ -11085,7 +11417,7 @@ spec:
                           default: Cookie
                           description: |-
                             Type defines the type of session persistence such as through
-                            the use a header or cookie. Defaults to cookie based session
+                            the use of a header or cookie. Defaults to cookie based session
                             persistence.
 
                             Support: Core for "Cookie" type
@@ -11101,6 +11433,8 @@ spec:
                           is Permanent
                         rule: '!has(self.cookieConfig) || !has(self.cookieConfig.lifetimeType)
                           || self.cookieConfig.lifetimeType != ''Permanent'' || has(self.absoluteTimeout)'
+                      - message: cookieConfig can only be set with type Cookie
+                        rule: '!has(self.cookieConfig) || self.type == ''Cookie'''
                     timeouts:
                       description: |-
                         Timeouts defines the timeouts that can be configured for an HTTP request.
@@ -11205,6 +11539,7 @@ spec:
                       != 1 || !has(self.matches[0].path) || self.matches[0].path.type
                       != ''PathPrefix'') ? false : true) : true'
                 maxItems: 16
+                minItems: 1
                 type: array
                 x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
@@ -11288,7 +11623,7 @@ spec:
 
                         * The Route refers to a nonexistent parent.
                         * The Route is of a type that the controller does not support.
-                        * The Route is in a namespace the controller does not have access to.
+                        * The Route is in a namespace to which the controller does not have access.
                       items:
                         description: Condition contains details for one aspect of
                           the current state of this API Resource.
@@ -11990,7 +12325,7 @@ spec:
                                         AllowHeaders indicates which HTTP request headers are supported for
                                         accessing the requested resource.
 
-                                        Header names are not case sensitive.
+                                        Header names are not case-sensitive.
 
                                         Multiple header names in the value of the `Access-Control-Allow-Headers`
                                         response header are separated by a comma (",").
@@ -12009,18 +12344,21 @@ spec:
                                         client side.
 
                                         A wildcard indicates that the requests with all HTTP headers are allowed.
-                                        The `Access-Control-Allow-Headers` response header can only use `*`
-                                        wildcard as value when the `AllowCredentials` field is false or omitted.
+                                        If config contains the wildcard "*" in allowHeaders and the request is
+                                        not credentialed, the `Access-Control-Allow-Headers` response header
+                                        can either use the `*` wildcard or the value of
+                                        Access-Control-Request-Headers from the request.
 
-                                        When the `AllowCredentials` field is true and `AllowHeaders` field
-                                        specified with the `*` wildcard, the gateway must specify one or more
+                                        When the request is credentialed, the gateway must not specify the `*`
+                                        wildcard in the `Access-Control-Allow-Headers` response header. When
+                                        also the `AllowCredentials` field is true and `AllowHeaders` field
+                                        is specified with the `*` wildcard, the gateway must specify one or more
                                         HTTP headers in the value of the `Access-Control-Allow-Headers` response
                                         header. The value of the header `Access-Control-Allow-Headers` is same as
                                         the `Access-Control-Request-Headers` header provided by the client. If
                                         the header `Access-Control-Request-Headers` is not included in the
                                         request, the gateway will omit the `Access-Control-Allow-Headers`
-                                        response header, instead of specifying the `*` wildcard. A Gateway
-                                        implementation may choose to add implementation-specific default headers.
+                                        response header, instead of specifying the `*` wildcard.
 
                                         Support: Extended
                                       items:
@@ -12044,6 +12382,10 @@ spec:
                                       maxItems: 64
                                       type: array
                                       x-kubernetes-list-type: set
+                                      x-kubernetes-validations:
+                                      - message: AllowHeaders cannot contain '*' alongside
+                                          other methods
+                                        rule: '!(''*'' in self && self.size() > 1)'
                                     allowMethods:
                                       description: |-
                                         AllowMethods indicates which HTTP methods are supported for accessing the
@@ -12052,7 +12394,7 @@ spec:
                                         Valid values are any method defined by RFC9110, along with the special
                                         value `*`, which represents all HTTP methods are allowed.
 
-                                        Method names are case sensitive, so these values are also case-sensitive.
+                                        Method names are case-sensitive, so these values are also case-sensitive.
                                         (See https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1)
 
                                         Multiple method names in the value of the `Access-Control-Allow-Methods`
@@ -12072,18 +12414,21 @@ spec:
                                         `Access-Control-Allow-Methods`, it will present an error on the client
                                         side.
 
-                                        The `Access-Control-Allow-Methods` response header can only use `*`
-                                        wildcard as value when the `AllowCredentials` field is false or omitted.
+                                        If config contains the wildcard "*" in allowMethods and the request is
+                                        not credentialed, the `Access-Control-Allow-Methods` response header
+                                        can either use the `*` wildcard or the value of
+                                        Access-Control-Request-Method from the request.
 
-                                        When the `AllowCredentials` field is true and `AllowMethods` field
+                                        When the request is credentialed, the gateway must not specify the `*`
+                                        wildcard in the `Access-Control-Allow-Methods` response header. When
+                                        also the `AllowCredentials` field is true and `AllowMethods` field
                                         specified with the `*` wildcard, the gateway must specify one HTTP method
                                         in the value of the Access-Control-Allow-Methods response header. The
                                         value of the header `Access-Control-Allow-Methods` is same as the
                                         `Access-Control-Request-Method` header provided by the client. If the
                                         header `Access-Control-Request-Method` is not included in the request,
                                         the gateway will omit the `Access-Control-Allow-Methods` response header,
-                                        instead of specifying the `*` wildcard. A Gateway implementation may
-                                        choose to add implementation-specific default methods.
+                                        instead of specifying the `*` wildcard.
 
                                         Support: Extended
                                       items:
@@ -12150,10 +12495,19 @@ spec:
                                         the CORS headers. The cross-origin request fails on the client side.
                                         Therefore, the client doesn't attempt the actual cross-origin request.
 
-                                        The `Access-Control-Allow-Origin` response header can only use `*`
-                                        wildcard as value when the `AllowCredentials` field is false or omitted.
+                                        Conversely, if the request `Origin` matches one of the configured
+                                        allowed origins, the gateway sets the response header
+                                        `Access-Control-Allow-Origin` to the same value as the `Origin`
+                                        header provided by the client.
 
-                                        When the `AllowCredentials` field is true and `AllowOrigins` field
+                                        When config has the wildcard ("*") in allowOrigins, and the request
+                                        is not credentialed (e.g., it is a preflight request), the
+                                        `Access-Control-Allow-Origin` response header either contains the
+                                        wildcard as well or the Origin from the request.
+
+                                        When the request is credentialed, the gateway must not specify the `*`
+                                        wildcard in the `Access-Control-Allow-Origin` response header. When
+                                        also the `AllowCredentials` field is true and `AllowOrigins` field
                                         specified with the `*` wildcard, the gateway must return a single origin
                                         in the value of the `Access-Control-Allow-Origin` response header,
                                         instead of specifying the `*` wildcard. The value of the header
@@ -12165,12 +12519,12 @@ spec:
                                         description: |-
                                           The CORSOrigin MUST NOT be a relative URI, and it MUST follow the URI syntax and
                                           encoding rules specified in RFC3986.  The CORSOrigin MUST include both a
-                                          scheme (e.g., "http" or "spiffe") and a scheme-specific-part, or it should be a single '*' character.
+                                          scheme ("http" or "https") and a scheme-specific-part, or it should be a single '*' character.
                                           URIs that include an authority MUST include a fully qualified domain name or
                                           IP address as the host.
                                         maxLength: 253
                                         minLength: 1
-                                        pattern: (^\*$)|(^([a-zA-Z][a-zA-Z0-9+\-.]+):\/\/([^:/?#]+)(:([0-9]{1,5}))?$)
+                                        pattern: (^\*$)|(^(http(s)?):\/\/(((\*\.)?([a-zA-Z0-9\-]+\.)*[a-zA-Z0-9-]+|\*)(:([0-9]{1,5}))?)$)
                                         type: string
                                       maxItems: 64
                                       type: array
@@ -12201,14 +12555,18 @@ spec:
                                         this additional header will be exposed as part of the response to the
                                         client.
 
-                                        Header names are not case sensitive.
+                                        Header names are not case-sensitive.
 
                                         Multiple header names in the value of the `Access-Control-Expose-Headers`
                                         response header are separated by a comma (",").
 
                                         A wildcard indicates that the responses with all HTTP headers are exposed
                                         to clients. The `Access-Control-Expose-Headers` response header can only
-                                        use `*` wildcard as value when the `AllowCredentials` field is false or omitted.
+                                        use `*` wildcard as value when the request is not credentialed.
+
+                                        When the `exposeHeaders` config field contains the "*" wildcard and
+                                        the request is credentialed, the gateway cannot use the `*` wildcard in
+                                        the `Access-Control-Expose-Headers` response header.
 
                                         Support: Extended
                                       items:
@@ -12244,6 +12602,9 @@ spec:
 
                                         The default value of `Access-Control-Max-Age` response header is 5
                                         (seconds).
+
+                                        When the `MaxAge` field is unspecified, the gateway sets the response
+                                        header "Access-Control-Max-Age: 5" by default.
                                       format: int32
                                       minimum: 1
                                       type: integer
@@ -12422,6 +12783,7 @@ spec:
                                             If the list has entries, only those entries must be sent.
                                           items:
                                             type: string
+                                          maxItems: 64
                                           type: array
                                           x-kubernetes-list-type: set
                                       type: object
@@ -12460,6 +12822,7 @@ spec:
                                             request must be set to the actual number of bytes forwarded.
                                           items:
                                             type: string
+                                          maxItems: 64
                                           type: array
                                           x-kubernetes-list-type: set
                                         allowedResponseHeaders:
@@ -12471,6 +12834,7 @@ spec:
                                             except Authority or Host must be copied.
                                           items:
                                             type: string
+                                          maxItems: 64
                                           type: array
                                           x-kubernetes-list-type: set
                                         path:
@@ -12575,10 +12939,14 @@ spec:
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
-                                            description: Value is the value of HTTP
-                                              Header to be matched.
+                                            description: |-
+                                              Value is the value of HTTP Header to be matched.
+
+                                              Must consist of printable US-ASCII characters, optionally separated
+                                              by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
                                             maxLength: 4096
                                             minLength: 1
+                                            pattern: ^[!-~]+([\t ]?[!-~]+)*$
                                             type: string
                                         required:
                                         - name
@@ -12650,10 +13018,14 @@ spec:
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
-                                            description: Value is the value of HTTP
-                                              Header to be matched.
+                                            description: |-
+                                              Value is the value of HTTP Header to be matched.
+
+                                              Must consist of printable US-ASCII characters, optionally separated
+                                              by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
                                             maxLength: 4096
                                             minLength: 1
+                                            pattern: ^[!-~]+([\t ]?[!-~]+)*$
                                             type: string
                                         required:
                                         - name
@@ -12964,6 +13336,9 @@ spec:
                                       enum:
                                       - 301
                                       - 302
+                                      - 303
+                                      - 307
+                                      - 308
                                       type: integer
                                   type: object
                                 responseHeaderModifier:
@@ -13011,10 +13386,14 @@ spec:
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
-                                            description: Value is the value of HTTP
-                                              Header to be matched.
+                                            description: |-
+                                              Value is the value of HTTP Header to be matched.
+
+                                              Must consist of printable US-ASCII characters, optionally separated
+                                              by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
                                             maxLength: 4096
                                             minLength: 1
+                                            pattern: ^[!-~]+([\t ]?[!-~]+)*$
                                             type: string
                                         required:
                                         - name
@@ -13086,10 +13465,14 @@ spec:
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
-                                            description: Value is the value of HTTP
-                                              Header to be matched.
+                                            description: |-
+                                              Value is the value of HTTP Header to be matched.
+
+                                              Must consist of printable US-ASCII characters, optionally separated
+                                              by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
                                             maxLength: 4096
                                             minLength: 1
+                                            pattern: ^[!-~]+([\t ]?[!-~]+)*$
                                             type: string
                                         required:
                                         - name
@@ -13233,6 +13616,11 @@ spec:
                               - type
                               type: object
                               x-kubernetes-validations:
+                              - message: filter.cors must be nil if the filter.type
+                                  is not CORS
+                                rule: '!(has(self.cors) && self.type != ''CORS'')'
+                              - message: filter.cors must be specified for CORS filter.type
+                                rule: '!(!has(self.cors) && self.type == ''CORS'')'
                               - message: filter.requestHeaderModifier must be nil
                                   if the filter.type is not RequestHeaderModifier
                                 rule: '!(has(self.requestHeaderModifier) && self.type
@@ -13276,11 +13664,6 @@ spec:
                               - message: filter.extensionRef must be specified for
                                   ExtensionRef filter.type
                                 rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
-                              - message: filter.cors must be nil if the filter.type
-                                  is not CORS
-                                rule: '!(has(self.cors) && self.type != ''CORS'')'
-                              - message: filter.cors must be specified for CORS filter.type
-                                rule: '!(!has(self.cors) && self.type == ''CORS'')'
                               - message: filter.externalAuth must be nil if the filter.type
                                   is not ExternalAuth
                                 rule: '!(has(self.externalAuth) && self.type != ''ExternalAuth'')'
@@ -13470,7 +13853,7 @@ spec:
                                   AllowHeaders indicates which HTTP request headers are supported for
                                   accessing the requested resource.
 
-                                  Header names are not case sensitive.
+                                  Header names are not case-sensitive.
 
                                   Multiple header names in the value of the `Access-Control-Allow-Headers`
                                   response header are separated by a comma (",").
@@ -13489,18 +13872,21 @@ spec:
                                   client side.
 
                                   A wildcard indicates that the requests with all HTTP headers are allowed.
-                                  The `Access-Control-Allow-Headers` response header can only use `*`
-                                  wildcard as value when the `AllowCredentials` field is false or omitted.
+                                  If config contains the wildcard "*" in allowHeaders and the request is
+                                  not credentialed, the `Access-Control-Allow-Headers` response header
+                                  can either use the `*` wildcard or the value of
+                                  Access-Control-Request-Headers from the request.
 
-                                  When the `AllowCredentials` field is true and `AllowHeaders` field
-                                  specified with the `*` wildcard, the gateway must specify one or more
+                                  When the request is credentialed, the gateway must not specify the `*`
+                                  wildcard in the `Access-Control-Allow-Headers` response header. When
+                                  also the `AllowCredentials` field is true and `AllowHeaders` field
+                                  is specified with the `*` wildcard, the gateway must specify one or more
                                   HTTP headers in the value of the `Access-Control-Allow-Headers` response
                                   header. The value of the header `Access-Control-Allow-Headers` is same as
                                   the `Access-Control-Request-Headers` header provided by the client. If
                                   the header `Access-Control-Request-Headers` is not included in the
                                   request, the gateway will omit the `Access-Control-Allow-Headers`
-                                  response header, instead of specifying the `*` wildcard. A Gateway
-                                  implementation may choose to add implementation-specific default headers.
+                                  response header, instead of specifying the `*` wildcard.
 
                                   Support: Extended
                                 items:
@@ -13524,6 +13910,10 @@ spec:
                                 maxItems: 64
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: AllowHeaders cannot contain '*' alongside
+                                    other methods
+                                  rule: '!(''*'' in self && self.size() > 1)'
                               allowMethods:
                                 description: |-
                                   AllowMethods indicates which HTTP methods are supported for accessing the
@@ -13532,7 +13922,7 @@ spec:
                                   Valid values are any method defined by RFC9110, along with the special
                                   value `*`, which represents all HTTP methods are allowed.
 
-                                  Method names are case sensitive, so these values are also case-sensitive.
+                                  Method names are case-sensitive, so these values are also case-sensitive.
                                   (See https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1)
 
                                   Multiple method names in the value of the `Access-Control-Allow-Methods`
@@ -13552,18 +13942,21 @@ spec:
                                   `Access-Control-Allow-Methods`, it will present an error on the client
                                   side.
 
-                                  The `Access-Control-Allow-Methods` response header can only use `*`
-                                  wildcard as value when the `AllowCredentials` field is false or omitted.
+                                  If config contains the wildcard "*" in allowMethods and the request is
+                                  not credentialed, the `Access-Control-Allow-Methods` response header
+                                  can either use the `*` wildcard or the value of
+                                  Access-Control-Request-Method from the request.
 
-                                  When the `AllowCredentials` field is true and `AllowMethods` field
+                                  When the request is credentialed, the gateway must not specify the `*`
+                                  wildcard in the `Access-Control-Allow-Methods` response header. When
+                                  also the `AllowCredentials` field is true and `AllowMethods` field
                                   specified with the `*` wildcard, the gateway must specify one HTTP method
                                   in the value of the Access-Control-Allow-Methods response header. The
                                   value of the header `Access-Control-Allow-Methods` is same as the
                                   `Access-Control-Request-Method` header provided by the client. If the
                                   header `Access-Control-Request-Method` is not included in the request,
                                   the gateway will omit the `Access-Control-Allow-Methods` response header,
-                                  instead of specifying the `*` wildcard. A Gateway implementation may
-                                  choose to add implementation-specific default methods.
+                                  instead of specifying the `*` wildcard.
 
                                   Support: Extended
                                 items:
@@ -13630,10 +14023,19 @@ spec:
                                   the CORS headers. The cross-origin request fails on the client side.
                                   Therefore, the client doesn't attempt the actual cross-origin request.
 
-                                  The `Access-Control-Allow-Origin` response header can only use `*`
-                                  wildcard as value when the `AllowCredentials` field is false or omitted.
+                                  Conversely, if the request `Origin` matches one of the configured
+                                  allowed origins, the gateway sets the response header
+                                  `Access-Control-Allow-Origin` to the same value as the `Origin`
+                                  header provided by the client.
 
-                                  When the `AllowCredentials` field is true and `AllowOrigins` field
+                                  When config has the wildcard ("*") in allowOrigins, and the request
+                                  is not credentialed (e.g., it is a preflight request), the
+                                  `Access-Control-Allow-Origin` response header either contains the
+                                  wildcard as well or the Origin from the request.
+
+                                  When the request is credentialed, the gateway must not specify the `*`
+                                  wildcard in the `Access-Control-Allow-Origin` response header. When
+                                  also the `AllowCredentials` field is true and `AllowOrigins` field
                                   specified with the `*` wildcard, the gateway must return a single origin
                                   in the value of the `Access-Control-Allow-Origin` response header,
                                   instead of specifying the `*` wildcard. The value of the header
@@ -13645,12 +14047,12 @@ spec:
                                   description: |-
                                     The CORSOrigin MUST NOT be a relative URI, and it MUST follow the URI syntax and
                                     encoding rules specified in RFC3986.  The CORSOrigin MUST include both a
-                                    scheme (e.g., "http" or "spiffe") and a scheme-specific-part, or it should be a single '*' character.
+                                    scheme ("http" or "https") and a scheme-specific-part, or it should be a single '*' character.
                                     URIs that include an authority MUST include a fully qualified domain name or
                                     IP address as the host.
                                   maxLength: 253
                                   minLength: 1
-                                  pattern: (^\*$)|(^([a-zA-Z][a-zA-Z0-9+\-.]+):\/\/([^:/?#]+)(:([0-9]{1,5}))?$)
+                                  pattern: (^\*$)|(^(http(s)?):\/\/(((\*\.)?([a-zA-Z0-9\-]+\.)*[a-zA-Z0-9-]+|\*)(:([0-9]{1,5}))?)$)
                                   type: string
                                 maxItems: 64
                                 type: array
@@ -13681,14 +14083,18 @@ spec:
                                   this additional header will be exposed as part of the response to the
                                   client.
 
-                                  Header names are not case sensitive.
+                                  Header names are not case-sensitive.
 
                                   Multiple header names in the value of the `Access-Control-Expose-Headers`
                                   response header are separated by a comma (",").
 
                                   A wildcard indicates that the responses with all HTTP headers are exposed
                                   to clients. The `Access-Control-Expose-Headers` response header can only
-                                  use `*` wildcard as value when the `AllowCredentials` field is false or omitted.
+                                  use `*` wildcard as value when the request is not credentialed.
+
+                                  When the `exposeHeaders` config field contains the "*" wildcard and
+                                  the request is credentialed, the gateway cannot use the `*` wildcard in
+                                  the `Access-Control-Expose-Headers` response header.
 
                                   Support: Extended
                                 items:
@@ -13724,6 +14130,9 @@ spec:
 
                                   The default value of `Access-Control-Max-Age` response header is 5
                                   (seconds).
+
+                                  When the `MaxAge` field is unspecified, the gateway sets the response
+                                  header "Access-Control-Max-Age: 5" by default.
                                 format: int32
                                 minimum: 1
                                 type: integer
@@ -13902,6 +14311,7 @@ spec:
                                       If the list has entries, only those entries must be sent.
                                     items:
                                       type: string
+                                    maxItems: 64
                                     type: array
                                     x-kubernetes-list-type: set
                                 type: object
@@ -13940,6 +14350,7 @@ spec:
                                       request must be set to the actual number of bytes forwarded.
                                     items:
                                       type: string
+                                    maxItems: 64
                                     type: array
                                     x-kubernetes-list-type: set
                                   allowedResponseHeaders:
@@ -13951,6 +14362,7 @@ spec:
                                       except Authority or Host must be copied.
                                     items:
                                       type: string
+                                    maxItems: 64
                                     type: array
                                     x-kubernetes-list-type: set
                                   path:
@@ -14052,10 +14464,14 @@ spec:
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: |-
+                                        Value is the value of HTTP Header to be matched.
+
+                                        Must consist of printable US-ASCII characters, optionally separated
+                                        by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
                                       maxLength: 4096
                                       minLength: 1
+                                      pattern: ^[!-~]+([\t ]?[!-~]+)*$
                                       type: string
                                   required:
                                   - name
@@ -14126,10 +14542,14 @@ spec:
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: |-
+                                        Value is the value of HTTP Header to be matched.
+
+                                        Must consist of printable US-ASCII characters, optionally separated
+                                        by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
                                       maxLength: 4096
                                       minLength: 1
+                                      pattern: ^[!-~]+([\t ]?[!-~]+)*$
                                       type: string
                                   required:
                                   - name
@@ -14440,6 +14860,9 @@ spec:
                                 enum:
                                 - 301
                                 - 302
+                                - 303
+                                - 307
+                                - 308
                                 type: integer
                             type: object
                           responseHeaderModifier:
@@ -14486,10 +14909,14 @@ spec:
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: |-
+                                        Value is the value of HTTP Header to be matched.
+
+                                        Must consist of printable US-ASCII characters, optionally separated
+                                        by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
                                       maxLength: 4096
                                       minLength: 1
+                                      pattern: ^[!-~]+([\t ]?[!-~]+)*$
                                       type: string
                                   required:
                                   - name
@@ -14560,10 +14987,14 @@ spec:
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: |-
+                                        Value is the value of HTTP Header to be matched.
+
+                                        Must consist of printable US-ASCII characters, optionally separated
+                                        by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
                                       maxLength: 4096
                                       minLength: 1
+                                      pattern: ^[!-~]+([\t ]?[!-~]+)*$
                                       type: string
                                   required:
                                   - name
@@ -14707,6 +15138,11 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
+                        - message: filter.cors must be nil if the filter.type is not
+                            CORS
+                          rule: '!(has(self.cors) && self.type != ''CORS'')'
+                        - message: filter.cors must be specified for CORS filter.type
+                          rule: '!(!has(self.cors) && self.type == ''CORS'')'
                         - message: filter.requestHeaderModifier must be nil if the
                             filter.type is not RequestHeaderModifier
                           rule: '!(has(self.requestHeaderModifier) && self.type !=
@@ -14747,11 +15183,6 @@ spec:
                         - message: filter.extensionRef must be specified for ExtensionRef
                             filter.type
                           rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
-                        - message: filter.cors must be nil if the filter.type is not
-                            CORS
-                          rule: '!(has(self.cors) && self.type != ''CORS'')'
-                        - message: filter.cors must be specified for CORS filter.type
-                          rule: '!(!has(self.cors) && self.type == ''CORS'')'
                         - message: filter.externalAuth must be nil if the filter.type
                             is not ExternalAuth
                           rule: '!(has(self.externalAuth) && self.type != ''ExternalAuth'')'
@@ -14897,10 +15328,14 @@ spec:
                                   - RegularExpression
                                   type: string
                                 value:
-                                  description: Value is the value of HTTP Header to
-                                    be matched.
+                                  description: |-
+                                    Value is the value of HTTP Header to be matched.
+
+                                    Must consist of printable US-ASCII characters, optionally separated
+                                    by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
                                   maxLength: 4096
                                   minLength: 1
+                                  pattern: ^[!-~]+([\t ]?[!-~]+)*$
                                   type: string
                               required:
                               - name
@@ -15109,7 +15544,7 @@ spec:
                             For example, setting the `rules[].retry.backoff` field to the value
                             `100ms` will cause a backend request to first be retried approximately
                             100 milliseconds after timing out or receiving a response code configured
-                            to be retryable.
+                            to be retriable.
 
                             An implementation MAY use an exponential or alternative backoff strategy
                             for subsequent retry attempts, MAY cap the maximum backoff duration to
@@ -15152,7 +15587,7 @@ spec:
                               HTTPRouteRetryStatusCode defines an HTTP response status code for
                               which a backend request should be retried.
 
-                              Implementations MUST support the following status codes as retryable:
+                              Implementations MUST support the following status codes as retriable:
 
                               * 500
                               * 502
@@ -15243,7 +15678,7 @@ spec:
                           default: Cookie
                           description: |-
                             Type defines the type of session persistence such as through
-                            the use a header or cookie. Defaults to cookie based session
+                            the use of a header or cookie. Defaults to cookie based session
                             persistence.
 
                             Support: Core for "Cookie" type
@@ -15259,6 +15694,8 @@ spec:
                           is Permanent
                         rule: '!has(self.cookieConfig) || !has(self.cookieConfig.lifetimeType)
                           || self.cookieConfig.lifetimeType != ''Permanent'' || has(self.absoluteTimeout)'
+                      - message: cookieConfig can only be set with type Cookie
+                        rule: '!has(self.cookieConfig) || self.type == ''Cookie'''
                     timeouts:
                       description: |-
                         Timeouts defines the timeouts that can be configured for an HTTP request.
@@ -15363,6 +15800,7 @@ spec:
                       != 1 || !has(self.matches[0].path) || self.matches[0].path.type
                       != ''PathPrefix'') ? false : true) : true'
                 maxItems: 16
+                minItems: 1
                 type: array
                 x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
@@ -15446,7 +15884,7 @@ spec:
 
                         * The Route refers to a nonexistent parent.
                         * The Route is of a type that the controller does not support.
-                        * The Route is in a namespace the controller does not have access to.
+                        * The Route is in a namespace to which the controller does not have access.
                       items:
                         description: Condition contains details for one aspect of
                           the current state of this API Resource.
@@ -15690,14 +16128,798 @@ status:
   storedVersions: null
 ---
 #
+# config/crd/experimental/gateway.networking.k8s.io_listenersets.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.0
+    gateway.networking.k8s.io/channel: experimental
+  name: listenersets.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: ListenerSet
+    listKind: ListenerSetList
+    plural: listenersets
+    shortNames:
+    - lset
+    singular: listenerset
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ListenerSet defines a set of additional listeners to attach to an existing Gateway.
+          This resource provides a mechanism to merge multiple listeners into a single Gateway.
+
+          The parent Gateway must explicitly allow ListenerSet attachment through its
+          AllowedListeners configuration. By default, Gateways do not allow ListenerSet
+          attachment.
+
+          Routes can attach to a ListenerSet by specifying it as a parentRef, and can
+          optionally target specific listeners using the sectionName field.
+
+          Policy Attachment:
+          - Policies that attach to a ListenerSet apply to all listeners defined in that resource
+          - Policies do not impact listeners in the parent Gateway
+          - Different ListenerSets attached to the same Gateway can have different policies
+          - If an implementation cannot apply a policy to specific listeners, it should reject the policy
+
+          ReferenceGrant Semantics:
+          - ReferenceGrants applied to a Gateway are not inherited by child ListenerSets
+          - ReferenceGrants applied to a ListenerSet do not grant permission to the parent Gateway's listeners
+          - A ListenerSet can reference secrets/backends in its own namespace without a ReferenceGrant
+
+          Gateway Integration:
+            - The parent Gateway's status will include "AttachedListenerSets"
+              which is the count of ListenerSets that have successfully attached to a Gateway
+              A ListenerSet is successfully attached to a Gateway when all the following conditions are met:
+            - The ListenerSet is selected by the Gateway's AllowedListeners field
+            - The ListenerSet has a valid ParentRef selecting the Gateway
+            - The ListenerSet's status has the condition "Accepted: true"
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of ListenerSet.
+            properties:
+              listeners:
+                description: |-
+                  Listeners associated with this ListenerSet. Listeners define
+                  logical endpoints that are bound on this referenced parent Gateway's addresses.
+
+                  Listeners in a `Gateway` and their attached `ListenerSets` are concatenated
+                  as a list when programming the underlying infrastructure. Each listener
+                  name does not need to be unique across the Gateway and ListenerSets.
+                  See ListenerEntry.Name for more details.
+
+                  Implementations MUST treat the parent Gateway as having the merged
+                  list of all listeners from itself and attached ListenerSets using
+                  the following precedence:
+
+                  1. "parent" Gateway
+                  2. ListenerSet ordered by creation time (oldest first)
+                  3. ListenerSet ordered alphabetically by "{namespace}/{name}".
+
+                  An implementation MAY reject listeners by setting the ListenerEntryStatus
+                  `Accepted` condition to False with the Reason `TooManyListeners`
+
+                  If a listener has a conflict, this will be reported in the
+                  Status.ListenerEntryStatus setting the `Conflicted` condition to True.
+
+                  Implementations SHOULD be cautious about what information from the
+                  parent or siblings are reported to avoid accidentally leaking
+                  sensitive information that the child would not otherwise have access
+                  to. This can include contents of secrets etc.
+                items:
+                  properties:
+                    allowedRoutes:
+                      default:
+                        namespaces:
+                          from: Same
+                      description: |-
+                        AllowedRoutes defines the types of routes that MAY be attached to a
+                        Listener and the trusted namespaces where those Route resources MAY be
+                        present.
+
+                        Although a client request may match multiple route rules, only one rule
+                        may ultimately receive the request. Matching precedence MUST be
+                        determined in order of the following criteria:
+
+                        * The most specific match as defined by the Route type.
+                        * The oldest Route based on creation timestamp. For example, a Route with
+                          a creation timestamp of "2020-09-08 01:02:03" is given precedence over
+                          a Route with a creation timestamp of "2020-09-08 01:02:04".
+                        * If everything else is equivalent, the Route appearing first in
+                          alphabetical order (namespace/name) should be given precedence. For
+                          example, foo/bar is given precedence over foo/baz.
+
+                        All valid rules within a Route attached to this Listener should be
+                        implemented. Invalid Route rules can be ignored (sometimes that will mean
+                        the full Route). If a Route rule transitions from valid to invalid,
+                        support for that Route rule should be dropped to ensure consistency. For
+                        example, even if a filter specified by a Route rule is invalid, the rest
+                        of the rules within that Route should still be supported.
+                      properties:
+                        kinds:
+                          description: |-
+                            Kinds specifies the groups and kinds of Routes that are allowed to bind
+                            to this Gateway Listener. When unspecified or empty, the kinds of Routes
+                            selected are determined using the Listener protocol.
+
+                            A RouteGroupKind MUST correspond to kinds of Routes that are compatible
+                            with the application protocol specified in the Listener's Protocol field.
+                            If an implementation does not support or recognize this resource type, it
+                            MUST set the "ResolvedRefs" condition to False for this Listener with the
+                            "InvalidRouteKinds" reason.
+
+                            Support: Core
+                          items:
+                            description: RouteGroupKind indicates the group and kind
+                              of a Route resource.
+                            properties:
+                              group:
+                                default: gateway.networking.k8s.io
+                                description: Group is the group of the Route.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                description: Kind is the kind of the Route.
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                            required:
+                            - kind
+                            type: object
+                          maxItems: 8
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        namespaces:
+                          default:
+                            from: Same
+                          description: |-
+                            Namespaces indicates namespaces from which Routes may be attached to this
+                            Listener. This is restricted to the namespace of this Gateway by default.
+
+                            Support: Core
+                          properties:
+                            from:
+                              default: Same
+                              description: |-
+                                From indicates where Routes will be selected for this Gateway. Possible
+                                values are:
+
+                                * All: Routes in all namespaces may be used by this Gateway.
+                                * Selector: Routes in namespaces selected by the selector may be used by
+                                  this Gateway.
+                                * Same: Only Routes in the same namespace may be used by this Gateway.
+
+                                Support: Core
+                              enum:
+                              - All
+                              - Selector
+                              - Same
+                              type: string
+                            selector:
+                              description: |-
+                                Selector must be specified when From is set to "Selector". In that case,
+                                only Routes in Namespaces matching this Selector will be selected by this
+                                Gateway. This field is ignored for other values of "From".
+
+                                Support: Core
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      type: object
+                    hostname:
+                      description: |-
+                        Hostname specifies the virtual hostname to match for protocol types that
+                        define this concept. When unspecified, all hostnames are matched. This
+                        field is ignored for protocols that don't require hostname based
+                        matching.
+
+                        Implementations MUST apply Hostname matching appropriately for each of
+                        the following protocols:
+
+                        * TLS: The Listener Hostname MUST match the SNI.
+                        * HTTP: The Listener Hostname MUST match the Host header of the request.
+                        * HTTPS: The Listener Hostname SHOULD match at both the TLS and HTTP
+                          protocol layers as described above. If an implementation does not
+                          ensure that both the SNI and Host header match the Listener hostname,
+                          it MUST clearly document that.
+
+                        For HTTPRoute and TLSRoute resources, there is an interaction with the
+                        `spec.hostnames` array. When both listener and route specify hostnames,
+                        there MUST be an intersection between the values for a Route to be
+                        accepted. For more information, refer to the Route specific Hostnames
+                        documentation.
+
+                        Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
+                        as a suffix match. That means that a match for `*.example.com` would match
+                        both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the Listener. This name MUST be unique within a
+                        ListenerSet.
+
+                        Name is not required to be unique across a Gateway and ListenerSets.
+                        Routes can attach to a Listener by having a ListenerSet as a parentRef
+                        and setting the SectionName
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port. Multiple listeners may use the
+                        same port, subject to the Listener compatibility rules.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    protocol:
+                      description: Protocol specifies the network protocol this listener
+                        expects to receive.
+                      maxLength: 255
+                      minLength: 1
+                      pattern: ^[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?$|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9]+$
+                      type: string
+                    tls:
+                      description: |-
+                        TLS is the TLS configuration for the Listener. This field is required if
+                        the Protocol field is "HTTPS" or "TLS". It is invalid to set this field
+                        if the Protocol field is "HTTP", "TCP", or "UDP".
+
+                        The association of SNIs to Certificate defined in ListenerTLSConfig is
+                        defined based on the Hostname field for this listener.
+
+                        The GatewayClass MUST use the longest matching SNI out of all
+                        available certificates for any TLS handshake.
+                      properties:
+                        certificateRefs:
+                          description: |-
+                            CertificateRefs contains a series of references to Kubernetes objects that
+                            contains TLS certificates and private keys. These certificates are used to
+                            establish a TLS handshake for requests that match the hostname of the
+                            associated listener.
+
+                            A single CertificateRef to a Kubernetes Secret has "Core" support.
+                            Implementations MAY choose to support attaching multiple certificates to
+                            a Listener, but this behavior is implementation-specific.
+
+                            References to a resource in different namespace are invalid UNLESS there
+                            is a ReferenceGrant in the target namespace that allows the certificate
+                            to be attached. If a ReferenceGrant does not allow this reference, the
+                            "ResolvedRefs" condition MUST be set to False for this listener with the
+                            "RefNotPermitted" reason.
+
+                            This field is required to have at least one element when the mode is set
+                            to "Terminate" (default) and is optional otherwise.
+
+                            CertificateRefs can reference to standard Kubernetes resources, i.e.
+                            Secret, or implementation-specific custom resources.
+
+                            Support: Core - A single reference to a Kubernetes Secret of type kubernetes.io/tls
+
+                            Support: Implementation-specific (More than one reference or other resource types)
+                          items:
+                            description: |-
+                              SecretObjectReference identifies an API object including its namespace,
+                              defaulting to Secret.
+
+                              The API object must be valid in the cluster; the Group and Kind must
+                              be registered in the cluster for this reference to be valid.
+
+                              References to objects with invalid Group and Kind are not valid, and must
+                              be rejected by the implementation, with appropriate Conditions set
+                              on the containing object.
+                            properties:
+                              group:
+                                default: ""
+                                description: |-
+                                  Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                  When unspecified or empty string, core API group is inferred.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                default: Secret
+                                description: Kind is kind of the referent. For example
+                                  "Secret".
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace is the namespace of the referenced object. When unspecified, the local
+                                  namespace is inferred.
+
+                                  Note that when a namespace different than the local namespace is specified,
+                                  a ReferenceGrant object is required in the referent namespace to allow that
+                                  namespace's owner to accept the reference. See the ReferenceGrant
+                                  documentation for details.
+
+                                  Support: Core
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          maxItems: 64
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        mode:
+                          default: Terminate
+                          description: |-
+                            Mode defines the TLS behavior for the TLS session initiated by the client.
+                            There are two possible modes:
+
+                            - Terminate: The TLS session between the downstream client and the
+                              Gateway is terminated at the Gateway. This mode requires certificates
+                              to be specified in some way, such as populating the certificateRefs
+                              field.
+                            - Passthrough: The TLS session is NOT terminated by the Gateway. This
+                              implies that the Gateway can't decipher the TLS stream except for
+                              the ClientHello message of the TLS protocol. The certificateRefs field
+                              is ignored in this mode.
+
+                            Support: Core
+                          enum:
+                          - Terminate
+                          - Passthrough
+                          type: string
+                        options:
+                          additionalProperties:
+                            description: |-
+                              AnnotationValue is the value of an annotation in Gateway API. This is used
+                              for validation of maps such as TLS options. This roughly matches Kubernetes
+                              annotation validation, although the length validation in that case is based
+                              on the entire size of the annotations struct.
+                            maxLength: 4096
+                            minLength: 0
+                            type: string
+                          description: |-
+                            Options are a list of key/value pairs to enable extended TLS
+                            configuration for each implementation. For example, configuring the
+                            minimum TLS version or supported cipher suites.
+
+                            A set of common keys MAY be defined by the API in the future. To avoid
+                            any ambiguity, implementation-specific definitions MUST use
+                            domain-prefixed names, such as `example.com/my-custom-option`.
+                            Un-prefixed names are reserved for key names defined by Gateway API.
+
+                            Support: Implementation-specific
+                          maxProperties: 16
+                          type: object
+                      type: object
+                      x-kubernetes-validations:
+                      - message: certificateRefs or options must be specified when
+                          mode is Terminate
+                        rule: 'self.mode == ''Terminate'' ? size(self.certificateRefs)
+                          > 0 || size(self.options) > 0 : true'
+                  required:
+                  - name
+                  - port
+                  - protocol
+                  type: object
+                maxItems: 64
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+                x-kubernetes-validations:
+                - message: tls must not be specified for protocols ['HTTP', 'TCP',
+                    'UDP']
+                  rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?
+                    !has(l.tls) : true)'
+                - message: tls mode must be Terminate for protocol HTTPS
+                  rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode
+                    == '''' || l.tls.mode == ''Terminate'') : true)'
+                - message: tls mode must be set for protocol TLS
+                  rule: 'self.all(l, (l.protocol == ''TLS'' ? has(l.tls) && has(l.tls.mode)
+                    && l.tls.mode != '''' : true))'
+                - message: hostname must not be specified for protocols ['TCP', 'UDP']
+                  rule: 'self.all(l, l.protocol in [''TCP'', ''UDP'']  ? (!has(l.hostname)
+                    || l.hostname == '''') : true)'
+                - message: Listener name must be unique within the Gateway
+                  rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
+                - message: Combination of port, protocol and hostname must be unique
+                    for each listener
+                  rule: 'self.all(l1, !has(l1.port) || self.exists_one(l2, has(l2.port)
+                    && l1.port == l2.port && l1.protocol == l2.protocol && (has(l1.hostname)
+                    && has(l2.hostname) ? l1.hostname == l2.hostname : !has(l1.hostname)
+                    && !has(l2.hostname))))'
+              parentRef:
+                description: ParentRef references the Gateway that the listeners are
+                  attached to.
+                properties:
+                  group:
+                    default: gateway.networking.k8s.io
+                    description: Group is the group of the referent.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    default: Gateway
+                    description: Kind is kind of the referent. For example "Gateway".
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the referent.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace is the namespace of the referent.  If not present,
+                      the namespace of the referent is assumed to be the same as
+                      the namespace of the referring object.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - listeners
+            - parentRef
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Accepted
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+            description: Status defines the current state of ListenerSet.
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: |-
+                  Conditions describe the current conditions of the ListenerSet.
+
+                  Implementations MUST express ListenerSet conditions using the
+                  `ListenerSetConditionType` and `ListenerSetConditionReason`
+                  constants so that operators and tools can converge on a common
+                  vocabulary to describe ListenerSet state.
+
+                  Known condition types are:
+
+                  * "Accepted"
+                  * "Programmed"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              listeners:
+                description: Listeners provide status for each unique listener port
+                  defined in the Spec.
+                items:
+                  description: ListenerStatus is the status associated with a Listener.
+                  properties:
+                    attachedRoutes:
+                      description: |-
+                        AttachedRoutes represents the total number of Routes that have been
+                        successfully attached to this Listener.
+
+                        Successful attachment of a Route to a Listener is based solely on the
+                        combination of the AllowedRoutes field on the corresponding Listener
+                        and the Route's ParentRefs field. A Route is successfully attached to
+                        a Listener when it is selected by the Listener's AllowedRoutes field
+                        AND the Route has a valid ParentRef selecting the whole Gateway
+                        resource or a specific Listener as a parent resource (more detail on
+                        attachment semantics can be found in the documentation on the various
+                        Route kinds ParentRefs fields). Listener status does not impact
+                        successful attachment, i.e. the AttachedRoutes field count MUST be set
+                        for Listeners, even if the Accepted condition of an individual Listener is set
+                        to "False". The AttachedRoutes number represents the number of Routes with
+                        the Accepted condition set to "True" that have been attached to this Listener.
+                        Routes with any other value for the Accepted condition MUST NOT be included
+                        in this count.
+
+                        Uses for this field include troubleshooting Route attachment and
+                        measuring blast radius/impact of changes to a Listener.
+                      format: int32
+                      type: integer
+                    conditions:
+                      description: Conditions describe the current condition of this
+                        listener.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    name:
+                      description: Name is the name of the Listener that this status
+                        corresponds to.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    supportedKinds:
+                      description: |-
+                        SupportedKinds is the list indicating the Kinds supported by this
+                        listener. This MUST represent the kinds supported by an implementation for
+                        that Listener configuration.
+
+                        If kinds are specified in Spec that are not supported, they MUST NOT
+                        appear in this list and an implementation MUST set the "ResolvedRefs"
+                        condition to "False" with the "InvalidRouteKinds" reason. If both valid
+                        and invalid Route kinds are specified, the implementation MUST
+                        reference the valid Route kinds that have been specified.
+                      items:
+                        description: RouteGroupKind indicates the group and kind of
+                          a Route resource.
+                        properties:
+                          group:
+                            default: gateway.networking.k8s.io
+                            description: Group is the group of the Route.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            description: Kind is the kind of the Route.
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                        required:
+                        - kind
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  required:
+                  - attachedRoutes
+                  - conditions
+                  - name
+                  type: object
+                maxItems: 64
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+#
 # config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
 #
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.1
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.0
     gateway.networking.k8s.io/channel: experimental
   name: referencegrants.gateway.networking.k8s.io
 spec:
@@ -15713,6 +16935,169 @@ spec:
     singular: referencegrant
   scope: Namespaced
   versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ReferenceGrant identifies kinds of resources in other namespaces that are
+          trusted to reference the specified kinds of resources in the same namespace
+          as the policy.
+
+          Each ReferenceGrant can be used to represent a unique trust relationship.
+          Additional Reference Grants can be used to add to the set of trusted
+          sources of inbound references for the namespace they are defined within.
+
+          All cross-namespace references in Gateway API (with the exception of cross-namespace
+          Gateway-route attachment) require a ReferenceGrant.
+
+          ReferenceGrant is a form of runtime verification allowing users to assert
+          which cross-namespace object references are permitted. Implementations that
+          support ReferenceGrant MUST NOT permit cross-namespace references which have
+          no grant, and MUST respond to the removal of a grant by revoking the access
+          that the grant allowed.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of ReferenceGrant.
+            properties:
+              from:
+                description: |-
+                  From describes the trusted namespaces and kinds that can reference the
+                  resources described in "To". Each entry in this list MUST be considered
+                  to be an additional place that references can be valid from, or to put
+                  this another way, entries MUST be combined using OR.
+
+                  Support: Core
+                items:
+                  description: ReferenceGrantFrom describes trusted namespaces and
+                    kinds.
+                  properties:
+                    group:
+                      description: |-
+                        Group is the group of the referent.
+                        When empty, the Kubernetes core API group is inferred.
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: |-
+                        Kind is the kind of the referent. Although implementations may support
+                        additional resources, the following types are part of the "Core"
+                        support level for this field.
+
+                        When used to permit a SecretObjectReference:
+
+                        * Gateway
+
+                        When used to permit a BackendObjectReference:
+
+                        * GRPCRoute
+                        * HTTPRoute
+                        * TCPRoute
+                        * TLSRoute
+                        * UDPRoute
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent.
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - namespace
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+              to:
+                description: |-
+                  To describes the resources that may be referenced by the resources
+                  described in "From". Each entry in this list MUST be considered to be an
+                  additional place that references can be valid to, or to put this another
+                  way, entries MUST be combined using OR.
+
+                  Support: Core
+                items:
+                  description: |-
+                    ReferenceGrantTo describes what Kinds are allowed as targets of the
+                    references.
+                  properties:
+                    group:
+                      description: |-
+                        Group is the group of the referent.
+                        When empty, the Kubernetes core API group is inferred.
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: |-
+                        Kind is the kind of the referent. Although implementations may support
+                        additional resources, the following types are part of the "Core"
+                        support level for this field:
+
+                        * Secret when used to permit a SecretObjectReference
+                        * Service when used to permit a BackendObjectReference
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent. When unspecified, this policy
+                        refers to all resources of the specified Group and Kind in the local
+                        namespace.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - from
+            - to
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources: {}
   - additionalPrinterColumns:
     - jsonPath: .metadata.creationTimestamp
       name: Age
@@ -15890,8 +17275,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.1
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.0
     gateway.networking.k8s.io/channel: experimental
   name: tcproutes.gateway.networking.k8s.io
 spec:
@@ -16400,7 +17785,7 @@ spec:
 
                         * The Route refers to a nonexistent parent.
                         * The Route is of a type that the controller does not support.
-                        * The Route is in a namespace the controller does not have access to.
+                        * The Route is in a namespace to which the controller does not have access.
                       items:
                         description: Condition contains details for one aspect of
                           the current state of this API Resource.
@@ -16650,8 +18035,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.1
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.0
     gateway.networking.k8s.io/channel: experimental
   name: tlsroutes.gateway.networking.k8s.io
 spec:
@@ -16669,7 +18054,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    name: v1alpha2
+    name: v1
     schema:
       openAPIV3Schema:
         description: |-
@@ -16679,6 +18064,781 @@ spec:
 
           If you need to forward traffic to a single target for a TLS listener, you
           could choose to use a TCPRoute with a TLS listener.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of TLSRoute.
+            properties:
+              hostnames:
+                description: |-
+                  Hostnames defines a set of SNI hostnames that should match against the
+                  SNI attribute of TLS ClientHello message in TLS handshake. This matches
+                  the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                  1. IPs are not allowed in SNI hostnames per RFC 6066.
+                  2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                     label must appear by itself as the first label.
+                items:
+                  description: |-
+                    Hostname is the fully qualified domain name of a network host. This matches
+                    the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                     1. IPs are not allowed.
+                     2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                        label must appear by itself as the first label.
+
+                    Hostname can be "precise" which is a domain name without the terminating
+                    dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                    domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+                    Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                    alphanumeric characters or '-', and must start and end with an alphanumeric
+                    character. No other punctuation is allowed.
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: Hostnames cannot contain an IP
+                  rule: self.all(h, !isIP(h))
+                - message: Hostnames must be valid based on RFC-1123
+                  rule: 'self.all(h, !h.contains(''*'') ? h.matches(''^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$'')
+                    : true)'
+                - message: Wildcards on hostnames must be the first label, and the
+                    rest of hostname must be valid based on RFC-1123
+                  rule: 'self.all(h, h.contains(''*'') ? (h.startsWith(''*.'') &&
+                    h.substring(2).matches(''^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$''))
+                    : true)'
+              parentRefs:
+                description: |-
+                  ParentRefs references the resources (usually Gateways) that a Route wants
+                  to be attached to. Note that the referenced parent resource needs to
+                  allow this for the attachment to be complete. For Gateways, that means
+                  the Gateway needs to allow attachment from Routes of this kind and
+                  namespace. For Services, that means the Service must either be in the same
+                  namespace for a "producer" route, or the mesh implementation must support
+                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                  not applicable for governing ParentRefs to Services - it is not possible to
+                  create a "producer" route for a Service in a different namespace from the
+                  Route.
+
+                  There are two kinds of parent resources with "Core" support:
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+                  ParentRefs must be _distinct_. This means either that:
+
+                  * They select different objects.  If this is the case, then parentRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                    be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field used,
+                    each ParentRef that selects the same object must set the same set of
+                    optional fields to different values. If one ParentRef sets a
+                    combination of optional fields, all must set the same combination.
+
+                  Some examples:
+
+                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                    same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                    object must also set `port`.
+                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                    referencing the same object must also set `sectionName` and `port`.
+
+                  It is possible to separately reference multiple distinct objects that may
+                  be collapsed by an implementation. For example, some implementations may
+                  choose to merge compatible Gateway Listeners together. If that is the
+                  case, the list of routes attached to those resources should also be
+                  merged.
+
+                  Note that for ParentRefs that cross namespace boundaries, there are specific
+                  rules. Cross-namespace references are only valid if they are explicitly
+                  allowed by something in the namespace they are referring to. For example,
+                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                  generic way to enable other kinds of cross-namespace reference.
+
+
+                  ParentRefs from a Route to a Service in the same namespace are "producer"
+                  routes, which apply default routing rules to inbound connections from
+                  any namespace to the Service.
+
+                  ParentRefs from a Route to a Service in a different namespace are
+                  "consumer" routes, and these routing rules are only applied to outbound
+                  connections originating from the same namespace as the Route, for which
+                  the intended destination of the connections are a Service targeted as a
+                  ParentRef of the Route.
+                items:
+                  description: |-
+                    ParentReference identifies an API object (usually a Gateway) that can be considered
+                    a parent of this resource (usually a route). There are two kinds of parent resources
+                    with "Core" support:
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+                    The API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: |-
+                        Group is the group of the referent.
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+                        To set the core API group (such as for a "Service" kind referent),
+                        Group must be explicitly set to "" (empty string).
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: |-
+                        Kind is kind of the referent.
+
+                        There are two kinds of parent resources with "Core" support:
+
+                        * Gateway (Gateway conformance profile)
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+                        Support for other resources is Implementation-Specific.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent. When unspecified, this refers
+                        to the local namespace of the Route.
+
+                        Note that there are specific rules for ParentRefs which cross namespace
+                        boundaries. Cross-namespace references are only valid if they are explicitly
+                        allowed by something in the namespace they are referring to. For example:
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+                        ParentRefs from a Route to a Service in the same namespace are "producer"
+                        routes, which apply default routing rules to inbound connections from
+                        any namespace to the Service.
+
+                        ParentRefs from a Route to a Service in a different namespace are
+                        "consumer" routes, and these routing rules are only applied to outbound
+                        connections originating from the same namespace as the Route, for which
+                        the intended destination of the connections are a Service targeted as a
+                        ParentRef of the Route.
+
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+
+                        When the parent resource is a Service, this targets a specific port in the
+                        Service spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified values.
+
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. In the
+                        following resources, SectionName is interpreted as the following:
+
+                        * Gateway: Listener name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+                        * Service: Port name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+
+                        Implementations MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName is
+                        interpreted.
+
+                        When unspecified (empty string), this will reference the entire resource.
+                        For the purpose of status, an attachment is considered successful if at
+                        least one section in the parent resource accepts it. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                        the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route, the
+                        Route MUST be considered detached from the Gateway.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: sectionName or port must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port)
+                    || p2.port == 0)): true))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
+              rules:
+                description: Rules are a list of actions.
+                items:
+                  description: TLSRouteRule is the configuration for a given rule.
+                  properties:
+                    backendRefs:
+                      description: |-
+                        BackendRefs defines the backend(s) where matching requests should be
+                        sent. If unspecified or invalid (refers to a nonexistent resource or
+                        a Service with no endpoints), the rule performs no forwarding; if no
+                        filters are specified that would result in a response being sent, the
+                        underlying implementation must actively reject request attempts to this
+                        backend, by rejecting the connection. Request rejections must respect
+                        weight; if an invalid backend is requested to have 80% of requests, then
+                        80% of requests must be rejected instead.
+
+                        Support: Core for Kubernetes Service
+
+                        Support: Extended for Kubernetes ServiceImport
+
+                        Support: Implementation-specific for any other resource
+
+                        Support for weight: Extended
+                      items:
+                        description: |-
+                          BackendRef defines how a Route should forward a request to a Kubernetes
+                          resource.
+
+                          Note that when a namespace different than the local namespace is specified, a
+                          ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+
+                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                          honor the appProtocol field if it is set for the target Service Port.
+
+                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                          Standard Application Protocols defined in KEP-3726.
+
+                          If a Service appProtocol isn't specified, an implementation MAY infer the
+                          backend protocol through its own means. Implementations MAY infer the
+                          protocol from the Route type referring to the backend Service.
+
+                          If a Route is not able to send traffic to the backend using the specified
+                          protocol then the backend is considered invalid. Implementations MUST set the
+                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+
+                          Note that when the BackendTLSPolicy object is enabled by the implementation,
+                          there are some extra rules about validity to consider here. See the fields
+                          where this struct is used for more information about the exact behavior.
+                        properties:
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: |-
+                              Kind is the Kubernetes resource kind of the referent. For example
+                              "Service".
+
+                              Defaults to "Service" when not specified.
+
+                              ExternalName services can refer to CNAME DNS records that may live
+                              outside of the cluster and as such are difficult to reason about in
+                              terms of conformance. They also may not be safe to forward to (see
+                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                              support ExternalName Services.
+
+                              Support: Core (Services with a type other than ExternalName)
+
+                              Support: Implementation-specific (Services with type ExternalName)
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the backend. When unspecified, the local
+                              namespace is inferred.
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port specifies the destination port number to use for this resource.
+                              Port is required when the referent is a Kubernetes Service. In this
+                              case, the port number is the service port number, not the target port.
+                              For other resources, destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: |-
+                              Weight specifies the proportion of requests forwarded to the referenced
+                              backend. This is computed as weight/(sum of all weights in this
+                              BackendRefs list). For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision an
+                              implementation supports. Weight is not a percentage and the sum of
+                              weights does not need to equal 100.
+
+                              If only one backend is specified and it has a weight greater than 0, 100%
+                              of the traffic is forwarded to that backend. If weight is set to 0, no
+                              traffic should be forwarded for this entry. If unspecified, weight
+                              defaults to 1.
+
+                              Support for this field varies based on the context where used.
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    name:
+                      description: Name is the name of the route rule. This name MUST
+                        be unique within a Route if it is set.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - backendRefs
+                  type: object
+                maxItems: 1
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+              useDefaultGateways:
+                description: |-
+                  UseDefaultGateways indicates the default Gateway scope to use for this
+                  Route. If unset (the default) or set to None, the Route will not be
+                  attached to any default Gateway; if set, it will be attached to any
+                  default Gateway supporting the named scope, subject to the usual rules
+                  about which Routes a Gateway is allowed to claim.
+
+                  Think carefully before using this functionality! The set of default
+                  Gateways supporting the requested scope can change over time without
+                  any notice to the Route author, and in many situations it will not be
+                  appropriate to request a default Gateway for a given Route -- for
+                  example, a Route with specific security requirements should almost
+                  certainly not use a default Gateway.
+                enum:
+                - All
+                - None
+                type: string
+            required:
+            - hostnames
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of TLSRoute.
+            properties:
+              parents:
+                description: |-
+                  Parents is a list of parent resources (usually Gateways) that are
+                  associated with the route, and the status of the route with respect to
+                  each parent. When this route attaches to a parent, the controller that
+                  manages the parent must add an entry to this list when the controller
+                  first sees the route and should update the entry as appropriate when the
+                  route or gateway is modified.
+
+                  Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this API
+                  can only populate Route status for the Gateways/parent resources they are
+                  responsible for.
+
+                  A maximum of 32 Gateways will be represented in this list. An empty list
+                  means the route has not been attached to any Gateway.
+                items:
+                  description: |-
+                    RouteParentStatus describes the status of a route with respect to an
+                    associated Parent.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes the status of the route with respect to the Gateway.
+                        Note that the route's availability is also subject to the Gateway's own
+                        status conditions and listener status.
+
+                        If the Route's ParentRef specifies an existing Gateway that supports
+                        Routes of this kind AND that Gateway's controller has sufficient access,
+                        then that Gateway's controller MUST set the "Accepted" condition on the
+                        Route, to indicate whether the route has been accepted or rejected by the
+                        Gateway, and why.
+
+                        A Route MUST be considered "Accepted" if at least one of the Route's
+                        rules is implemented by the Gateway.
+
+                        There are a number of cases where the "Accepted" condition may not be set
+                        due to lack of controller visibility, that includes when:
+
+                        * The Route refers to a nonexistent parent.
+                        * The Route is of a type that the controller does not support.
+                        * The Route is in a namespace to which the controller does not have access.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: |-
+                        ParentRef corresponds with a ParentRef in the spec that this
+                        RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - conditions
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: The v1alpha2 version of TLSRoute has been deprecated and will
+      be removed in a future release of the API. Please upgrade to v1.
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: |-
+          The TLSRoute resource is similar to TCPRoute, but can be configured
+          to match against TLS-specific metadata. This allows more flexibility
+          in matching streams for a given TLS listener.
         properties:
           apiVersion:
             description: |-
@@ -17006,10 +19166,9 @@ spec:
                         a Service with no endpoints), the rule performs no forwarding; if no
                         filters are specified that would result in a response being sent, the
                         underlying implementation must actively reject request attempts to this
-                        backend, by rejecting the connection or returning a 500 status code.
-                        Request rejections must respect weight; if an invalid backend is
-                        requested to have 80% of requests, then 80% of requests must be rejected
-                        instead.
+                        backend, by rejecting the connection. Request rejections must respect
+                        weight; if an invalid backend is requested to have 80% of requests, then
+                        80% of requests must be rejected instead.
 
                         Support: Core for Kubernetes Service
 
@@ -17140,10 +19299,8 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     name:
-                      description: |-
-                        Name is the name of the route rule. This name MUST be unique within a Route if it is set.
-
-                        Support: Extended
+                      description: Name is the name of the route rule. This name MUST
+                        be unique within a Route if it is set.
                       maxLength: 253
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -17224,7 +19381,7 @@ spec:
 
                         * The Route refers to a nonexistent parent.
                         * The Route is of a type that the controller does not support.
-                        * The Route is in a namespace the controller does not have access to.
+                        * The Route is in a namespace to which the controller does not have access.
                       items:
                         description: Condition contains details for one aspect of
                           the current state of this API Resource.
@@ -17464,6 +19621,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: The v1alpha3 version of TLSRoute has been deprecated and will
+      be removed in a future release of the API. Please upgrade to v1.
     name: v1alpha3
     schema:
       openAPIV3Schema:
@@ -17504,32 +19664,6 @@ spec:
                   1. IPs are not allowed in SNI hostnames per RFC 6066.
                   2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
                      label must appear by itself as the first label.
-
-                  If a hostname is specified by both the Listener and TLSRoute, there
-                  must be at least one intersecting hostname for the TLSRoute to be
-                  attached to the Listener. For example:
-
-                  * A Listener with `test.example.com` as the hostname matches TLSRoutes
-                    that have specified at least one of `test.example.com` or
-                    `*.example.com`.
-                  * A Listener with `*.example.com` as the hostname matches TLSRoutes
-                    that have specified at least one hostname that matches the Listener
-                    hostname. For example, `test.example.com` and `*.example.com` would both
-                    match. On the other hand, `example.com` and `test.example.net` would not
-                    match.
-
-                  If both the Listener and TLSRoute have specified hostnames, any
-                  TLSRoute hostnames that do not match the Listener hostname MUST be
-                  ignored. For example, if a Listener specified `*.example.com`, and the
-                  TLSRoute specified `test.example.com` and `test.example.net`,
-                  `test.example.net` must not be considered for a match.
-
-                  If both the Listener and TLSRoute have specified hostnames, and none
-                  match with the criteria above, then the TLSRoute is not accepted. The
-                  implementation must raise an 'Accepted' Condition with a status of
-                  `False` in the corresponding RouteParentStatus.
-
-                  Support: Core
                 items:
                   description: |-
                     Hostname is the fully qualified domain name of a network host. This matches
@@ -17554,6 +19688,17 @@ spec:
                 minItems: 1
                 type: array
                 x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: Hostnames cannot contain an IP
+                  rule: self.all(h, !isIP(h))
+                - message: Hostnames must be valid based on RFC-1123
+                  rule: 'self.all(h, !h.contains(''*'') ? h.matches(''^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$'')
+                    : true)'
+                - message: Wildcards on hostnames must be the first label, and the
+                    rest of hostname must be valid based on RFC-1123
+                  rule: 'self.all(h, h.contains(''*'') ? (h.startsWith(''*.'') &&
+                    h.substring(2).matches(''^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$''))
+                    : true)'
               parentRefs:
                 description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants
@@ -17802,10 +19947,9 @@ spec:
                         a Service with no endpoints), the rule performs no forwarding; if no
                         filters are specified that would result in a response being sent, the
                         underlying implementation must actively reject request attempts to this
-                        backend, by rejecting the connection or returning a 500 status code.
-                        Request rejections must respect weight; if an invalid backend is
-                        requested to have 80% of requests, then 80% of requests must be rejected
-                        instead.
+                        backend, by rejecting the connection. Request rejections must respect
+                        weight; if an invalid backend is requested to have 80% of requests, then
+                        80% of requests must be rejected instead.
 
                         Support: Core for Kubernetes Service
 
@@ -17936,10 +20080,8 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     name:
-                      description: |-
-                        Name is the name of the route rule. This name MUST be unique within a Route if it is set.
-
-                        Support: Extended
+                      description: Name is the name of the route rule. This name MUST
+                        be unique within a Route if it is set.
                       maxLength: 253
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -17951,10 +20093,6 @@ spec:
                 minItems: 1
                 type: array
                 x-kubernetes-list-type: atomic
-                x-kubernetes-validations:
-                - message: Rule name must be unique within the route
-                  rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name)
-                    && l1.name == l2.name))
               useDefaultGateways:
                 description: |-
                   UseDefaultGateways indicates the default Gateway scope to use for this
@@ -18021,7 +20159,7 @@ spec:
 
                         * The Route refers to a nonexistent parent.
                         * The Route is of a type that the controller does not support.
-                        * The Route is in a namespace the controller does not have access to.
+                        * The Route is in a namespace to which the controller does not have access.
                       items:
                         description: Condition contains details for one aspect of
                           the current state of this API Resource.
@@ -18254,7 +20392,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
 status:
@@ -18271,8 +20409,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.1
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.0
     gateway.networking.k8s.io/channel: experimental
   name: udproutes.gateway.networking.k8s.io
 spec:
@@ -18781,7 +20919,7 @@ spec:
 
                         * The Route refers to a nonexistent parent.
                         * The Route is of a type that the controller does not support.
-                        * The Route is in a namespace the controller does not have access to.
+                        * The Route is in a namespace to which the controller does not have access.
                       items:
                         description: Condition contains details for one aspect of
                           the current state of this API Resource.
@@ -19025,14 +21163,66 @@ status:
   storedVersions: null
 ---
 #
+# config/crd/experimental/gateway.networking.k8s.io_vap_safeupgrades.yaml
+#
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  annotations:
+    gateway.networking.k8s.io/bundle-version: v1.5.0-dev
+    gateway.networking.k8s.io/channel: standard
+  name: "safe-upgrades.gateway.networking.k8s.io"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["apiextensions.k8s.io"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["*"]
+  validations:
+    - expression: "object.spec.group != 'gateway.networking.k8s.io' || oldObject == null || (
+        has(object.metadata.annotations) && object.metadata.annotations.exists(k, k == 'gateway.networking.k8s.io/channel') && 
+        object.metadata.annotations['gateway.networking.k8s.io/channel'] == 'standard' ) || (
+        oldObject != null && has(oldObject.metadata.annotations) && oldObject.metadata.annotations.exists(k, k == 'gateway.networking.k8s.io/channel') && 
+        oldObject.metadata.annotations['gateway.networking.k8s.io/channel'] == 'experimental' )"
+      message: "Installing experimental CRDs on top of standard channel CRDs is prohibited by default. Uninstall ValidatingAdmissionPolicy safe-upgrades.gateway.networking.k8s.io to install experimental CRDs on top of standard channel CRDs."
+      reason: Invalid
+    - expression: "object.spec.group != 'gateway.networking.k8s.io' ||
+        (has(object.metadata.annotations) && object.metadata.annotations.exists(k, k == 'gateway.networking.k8s.io/bundle-version') &&
+        !matches(object.metadata.annotations['gateway.networking.k8s.io/bundle-version'], 'v1.[0-4].\\\\d+') &&
+        !matches(object.metadata.annotations['gateway.networking.k8s.io/bundle-version'], 'v0'))" #TODO Kubernetes 1.37: Migrate to kubernetes semver library
+      message: "Installing CRDs with version before v1.5.0 is prohibited by default. Uninstall ValidatingAdmissionPolicy safe-upgrades.gateway.networking.k8s.io to install older versions."
+      reason: Invalid
+
+---
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  annotations:
+    gateway.networking.k8s.io/bundle-version: v1.5.0-dev
+    gateway.networking.k8s.io/channel: standard
+  name: safe-upgrades.gateway.networking.k8s.io
+spec:
+  policyName: safe-upgrades.gateway.networking.k8s.io
+  validationActions: [Deny]
+  matchResources:
+    resourceRules:
+    - apiGroups:   ["apiextensions.k8s.io"]
+      apiVersions: ["v1"]
+      resources:   ["customresourcedefinitions"]
+      operations:  ["CREATE", "UPDATE"]
+---
+#
 # config/crd/experimental/gateway.networking.x-k8s.io_xbackendtrafficpolicies.yaml
 #
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.1
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.0
     gateway.networking.k8s.io/channel: experimental
   labels:
     gateway.networking.k8s.io/policy: Direct
@@ -19129,7 +21319,7 @@ spec:
                         pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                         type: string
                         x-kubernetes-validations:
-                        - message: interval can not be greater than one hour or less
+                        - message: interval cannot be greater than one hour or less
                             than one second
                           rule: '!(duration(self) < duration(''1s'') || duration(self)
                             > duration(''1h''))'
@@ -19179,7 +21369,7 @@ spec:
                         pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                         type: string
                         x-kubernetes-validations:
-                        - message: interval can not be greater than one hour
+                        - message: interval cannot be greater than one hour
                           rule: '!(duration(self) == duration(''0s'') || duration(self)
                             > duration(''1h''))'
                     type: object
@@ -19257,7 +21447,7 @@ spec:
                     default: Cookie
                     description: |-
                       Type defines the type of session persistence such as through
-                      the use a header or cookie. Defaults to cookie based session
+                      the use of a header or cookie. Defaults to cookie based session
                       persistence.
 
                       Support: Core for "Cookie" type
@@ -19273,6 +21463,8 @@ spec:
                     is Permanent
                   rule: '!has(self.cookieConfig) || !has(self.cookieConfig.lifetimeType)
                     || self.cookieConfig.lifetimeType != ''Permanent'' || has(self.absoluteTimeout)'
+                - message: cookieConfig can only be set with type Cookie
+                  rule: '!has(self.cookieConfig) || self.type == ''Cookie'''
               targetRefs:
                 description: |-
                   TargetRefs identifies API object(s) to apply this policy to.
@@ -19280,7 +21472,7 @@ spec:
                   ServiceImport, or any implementation-specific backendRef) are the only
                   valid API target references.
 
-                  Currently, a TargetRef can not be scoped to a specific port on a
+                  Currently, a TargetRef cannot be scoped to a specific port on a
                   Service.
                 items:
                   description: |-
@@ -19635,805 +21827,14 @@ status:
   storedVersions: null
 ---
 #
-# config/crd/experimental/gateway.networking.x-k8s.io_xlistenersets.yaml
-#
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.1
-    gateway.networking.k8s.io/channel: experimental
-  name: xlistenersets.gateway.networking.x-k8s.io
-spec:
-  group: gateway.networking.x-k8s.io
-  names:
-    categories:
-    - gateway-api
-    kind: XListenerSet
-    listKind: XListenerSetList
-    plural: xlistenersets
-    shortNames:
-    - lset
-    singular: xlistenerset
-  scope: Namespaced
-  versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status.conditions[?(@.type=="Accepted")].status
-      name: Accepted
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
-      name: Programmed
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: |-
-          XListenerSet defines a set of additional listeners to attach to an existing Gateway.
-          This resource provides a mechanism to merge multiple listeners into a single Gateway.
-
-          The parent Gateway must explicitly allow ListenerSet attachment through its
-          AllowedListeners configuration. By default, Gateways do not allow ListenerSet
-          attachment.
-
-          Routes can attach to a ListenerSet by specifying it as a parentRef, and can
-          optionally target specific listeners using the sectionName field.
-
-          Policy Attachment:
-          - Policies that attach to a ListenerSet apply to all listeners defined in that resource
-          - Policies do not impact listeners in the parent Gateway
-          - Different ListenerSets attached to the same Gateway can have different policies
-          - If an implementation cannot apply a policy to specific listeners, it should reject the policy
-
-          ReferenceGrant Semantics:
-          - ReferenceGrants applied to a Gateway are not inherited by child ListenerSets
-          - ReferenceGrants applied to a ListenerSet do not grant permission to the parent Gateway's listeners
-          - A ListenerSet can reference secrets/backends in its own namespace without a ReferenceGrant
-
-          Gateway Integration:
-          - The parent Gateway's status will include an "AttachedListenerSets" condition
-          - This condition will be:
-            - True: when AllowedListeners is set and at least one child ListenerSet is attached
-            - False: when AllowedListeners is set but no valid listeners are attached, or when AllowedListeners is not set or false
-            - Unknown: when no AllowedListeners config is present
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec defines the desired state of ListenerSet.
-            properties:
-              listeners:
-                description: |-
-                  Listeners associated with this ListenerSet. Listeners define
-                  logical endpoints that are bound on this referenced parent Gateway's addresses.
-
-                  Listeners in a `Gateway` and their attached `ListenerSets` are concatenated
-                  as a list when programming the underlying infrastructure. Each listener
-                  name does not need to be unique across the Gateway and ListenerSets.
-                  See ListenerEntry.Name for more details.
-
-                  Implementations MUST treat the parent Gateway as having the merged
-                  list of all listeners from itself and attached ListenerSets using
-                  the following precedence:
-
-                  1. "parent" Gateway
-                  2. ListenerSet ordered by creation time (oldest first)
-                  3. ListenerSet ordered alphabetically by "{namespace}/{name}".
-
-                  An implementation MAY reject listeners by setting the ListenerEntryStatus
-                  `Accepted` condition to False with the Reason `TooManyListeners`
-
-                  If a listener has a conflict, this will be reported in the
-                  Status.ListenerEntryStatus setting the `Conflicted` condition to True.
-
-                  Implementations SHOULD be cautious about what information from the
-                  parent or siblings are reported to avoid accidentally leaking
-                  sensitive information that the child would not otherwise have access
-                  to. This can include contents of secrets etc.
-                items:
-                  properties:
-                    allowedRoutes:
-                      default:
-                        namespaces:
-                          from: Same
-                      description: |-
-                        AllowedRoutes defines the types of routes that MAY be attached to a
-                        Listener and the trusted namespaces where those Route resources MAY be
-                        present.
-
-                        Although a client request may match multiple route rules, only one rule
-                        may ultimately receive the request. Matching precedence MUST be
-                        determined in order of the following criteria:
-
-                        * The most specific match as defined by the Route type.
-                        * The oldest Route based on creation timestamp. For example, a Route with
-                          a creation timestamp of "2020-09-08 01:02:03" is given precedence over
-                          a Route with a creation timestamp of "2020-09-08 01:02:04".
-                        * If everything else is equivalent, the Route appearing first in
-                          alphabetical order (namespace/name) should be given precedence. For
-                          example, foo/bar is given precedence over foo/baz.
-
-                        All valid rules within a Route attached to this Listener should be
-                        implemented. Invalid Route rules can be ignored (sometimes that will mean
-                        the full Route). If a Route rule transitions from valid to invalid,
-                        support for that Route rule should be dropped to ensure consistency. For
-                        example, even if a filter specified by a Route rule is invalid, the rest
-                        of the rules within that Route should still be supported.
-                      properties:
-                        kinds:
-                          description: |-
-                            Kinds specifies the groups and kinds of Routes that are allowed to bind
-                            to this Gateway Listener. When unspecified or empty, the kinds of Routes
-                            selected are determined using the Listener protocol.
-
-                            A RouteGroupKind MUST correspond to kinds of Routes that are compatible
-                            with the application protocol specified in the Listener's Protocol field.
-                            If an implementation does not support or recognize this resource type, it
-                            MUST set the "ResolvedRefs" condition to False for this Listener with the
-                            "InvalidRouteKinds" reason.
-
-                            Support: Core
-                          items:
-                            description: RouteGroupKind indicates the group and kind
-                              of a Route resource.
-                            properties:
-                              group:
-                                default: gateway.networking.k8s.io
-                                description: Group is the group of the Route.
-                                maxLength: 253
-                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                type: string
-                              kind:
-                                description: Kind is the kind of the Route.
-                                maxLength: 63
-                                minLength: 1
-                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                type: string
-                            required:
-                            - kind
-                            type: object
-                          maxItems: 8
-                          type: array
-                          x-kubernetes-list-type: atomic
-                        namespaces:
-                          default:
-                            from: Same
-                          description: |-
-                            Namespaces indicates namespaces from which Routes may be attached to this
-                            Listener. This is restricted to the namespace of this Gateway by default.
-
-                            Support: Core
-                          properties:
-                            from:
-                              default: Same
-                              description: |-
-                                From indicates where Routes will be selected for this Gateway. Possible
-                                values are:
-
-                                * All: Routes in all namespaces may be used by this Gateway.
-                                * Selector: Routes in namespaces selected by the selector may be used by
-                                  this Gateway.
-                                * Same: Only Routes in the same namespace may be used by this Gateway.
-
-                                Support: Core
-                              enum:
-                              - All
-                              - Selector
-                              - Same
-                              type: string
-                            selector:
-                              description: |-
-                                Selector must be specified when From is set to "Selector". In that case,
-                                only Routes in Namespaces matching this Selector will be selected by this
-                                Gateway. This field is ignored for other values of "From".
-
-                                Support: Core
-                              properties:
-                                matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
-                                  items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
-                                    properties:
-                                      key:
-                                        description: key is the label key that the
-                                          selector applies to.
-                                        type: string
-                                      operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
-                                        type: string
-                                      values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                  type: object
-                              type: object
-                              x-kubernetes-map-type: atomic
-                          type: object
-                      type: object
-                    hostname:
-                      description: |-
-                        Hostname specifies the virtual hostname to match for protocol types that
-                        define this concept. When unspecified, all hostnames are matched. This
-                        field is ignored for protocols that don't require hostname based
-                        matching.
-
-                        Implementations MUST apply Hostname matching appropriately for each of
-                        the following protocols:
-
-                        * TLS: The Listener Hostname MUST match the SNI.
-                        * HTTP: The Listener Hostname MUST match the Host header of the request.
-                        * HTTPS: The Listener Hostname SHOULD match at both the TLS and HTTP
-                          protocol layers as described above. If an implementation does not
-                          ensure that both the SNI and Host header match the Listener hostname,
-                          it MUST clearly document that.
-
-                        For HTTPRoute and TLSRoute resources, there is an interaction with the
-                        `spec.hostnames` array. When both listener and route specify hostnames,
-                        there MUST be an intersection between the values for a Route to be
-                        accepted. For more information, refer to the Route specific Hostnames
-                        documentation.
-
-                        Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
-                        as a suffix match. That means that a match for `*.example.com` would match
-                        both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
-                      maxLength: 253
-                      minLength: 1
-                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                      type: string
-                    name:
-                      description: |-
-                        Name is the name of the Listener. This name MUST be unique within a
-                        ListenerSet.
-
-                        Name is not required to be unique across a Gateway and ListenerSets.
-                        Routes can attach to a Listener by having a ListenerSet as a parentRef
-                        and setting the SectionName
-                      maxLength: 253
-                      minLength: 1
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                      type: string
-                    port:
-                      default: 0
-                      description: |-
-                        Port is the network port. Multiple listeners may use the
-                        same port, subject to the Listener compatibility rules.
-
-                        If the port is not set or specified as zero, the implementation will assign
-                        a unique port. If the implementation does not support dynamic port
-                        assignment, it MUST set `Accepted` condition to `False` with the
-                        `UnsupportedPort` reason.
-                      format: int32
-                      maximum: 65535
-                      minimum: 0
-                      type: integer
-                    protocol:
-                      description: Protocol specifies the network protocol this listener
-                        expects to receive.
-                      maxLength: 255
-                      minLength: 1
-                      pattern: ^[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?$|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9]+$
-                      type: string
-                    tls:
-                      description: |-
-                        TLS is the TLS configuration for the Listener. This field is required if
-                        the Protocol field is "HTTPS" or "TLS". It is invalid to set this field
-                        if the Protocol field is "HTTP", "TCP", or "UDP".
-
-                        The association of SNIs to Certificate defined in ListenerTLSConfig is
-                        defined based on the Hostname field for this listener.
-
-                        The GatewayClass MUST use the longest matching SNI out of all
-                        available certificates for any TLS handshake.
-                      properties:
-                        certificateRefs:
-                          description: |-
-                            CertificateRefs contains a series of references to Kubernetes objects that
-                            contains TLS certificates and private keys. These certificates are used to
-                            establish a TLS handshake for requests that match the hostname of the
-                            associated listener.
-
-                            A single CertificateRef to a Kubernetes Secret has "Core" support.
-                            Implementations MAY choose to support attaching multiple certificates to
-                            a Listener, but this behavior is implementation-specific.
-
-                            References to a resource in different namespace are invalid UNLESS there
-                            is a ReferenceGrant in the target namespace that allows the certificate
-                            to be attached. If a ReferenceGrant does not allow this reference, the
-                            "ResolvedRefs" condition MUST be set to False for this listener with the
-                            "RefNotPermitted" reason.
-
-                            This field is required to have at least one element when the mode is set
-                            to "Terminate" (default) and is optional otherwise.
-
-                            CertificateRefs can reference to standard Kubernetes resources, i.e.
-                            Secret, or implementation-specific custom resources.
-
-                            Support: Core - A single reference to a Kubernetes Secret of type kubernetes.io/tls
-
-                            Support: Implementation-specific (More than one reference or other resource types)
-                          items:
-                            description: |-
-                              SecretObjectReference identifies an API object including its namespace,
-                              defaulting to Secret.
-
-                              The API object must be valid in the cluster; the Group and Kind must
-                              be registered in the cluster for this reference to be valid.
-
-                              References to objects with invalid Group and Kind are not valid, and must
-                              be rejected by the implementation, with appropriate Conditions set
-                              on the containing object.
-                            properties:
-                              group:
-                                default: ""
-                                description: |-
-                                  Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                  When unspecified or empty string, core API group is inferred.
-                                maxLength: 253
-                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                type: string
-                              kind:
-                                default: Secret
-                                description: Kind is kind of the referent. For example
-                                  "Secret".
-                                maxLength: 63
-                                minLength: 1
-                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                type: string
-                              name:
-                                description: Name is the name of the referent.
-                                maxLength: 253
-                                minLength: 1
-                                type: string
-                              namespace:
-                                description: |-
-                                  Namespace is the namespace of the referenced object. When unspecified, the local
-                                  namespace is inferred.
-
-                                  Note that when a namespace different than the local namespace is specified,
-                                  a ReferenceGrant object is required in the referent namespace to allow that
-                                  namespace's owner to accept the reference. See the ReferenceGrant
-                                  documentation for details.
-
-                                  Support: Core
-                                maxLength: 63
-                                minLength: 1
-                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                                type: string
-                            required:
-                            - name
-                            type: object
-                          maxItems: 64
-                          type: array
-                          x-kubernetes-list-type: atomic
-                        mode:
-                          default: Terminate
-                          description: |-
-                            Mode defines the TLS behavior for the TLS session initiated by the client.
-                            There are two possible modes:
-
-                            - Terminate: The TLS session between the downstream client and the
-                              Gateway is terminated at the Gateway. This mode requires certificates
-                              to be specified in some way, such as populating the certificateRefs
-                              field.
-                            - Passthrough: The TLS session is NOT terminated by the Gateway. This
-                              implies that the Gateway can't decipher the TLS stream except for
-                              the ClientHello message of the TLS protocol. The certificateRefs field
-                              is ignored in this mode.
-
-                            Support: Core
-                          enum:
-                          - Terminate
-                          - Passthrough
-                          type: string
-                        options:
-                          additionalProperties:
-                            description: |-
-                              AnnotationValue is the value of an annotation in Gateway API. This is used
-                              for validation of maps such as TLS options. This roughly matches Kubernetes
-                              annotation validation, although the length validation in that case is based
-                              on the entire size of the annotations struct.
-                            maxLength: 4096
-                            minLength: 0
-                            type: string
-                          description: |-
-                            Options are a list of key/value pairs to enable extended TLS
-                            configuration for each implementation. For example, configuring the
-                            minimum TLS version or supported cipher suites.
-
-                            A set of common keys MAY be defined by the API in the future. To avoid
-                            any ambiguity, implementation-specific definitions MUST use
-                            domain-prefixed names, such as `example.com/my-custom-option`.
-                            Un-prefixed names are reserved for key names defined by Gateway API.
-
-                            Support: Implementation-specific
-                          maxProperties: 16
-                          type: object
-                      type: object
-                      x-kubernetes-validations:
-                      - message: certificateRefs or options must be specified when
-                          mode is Terminate
-                        rule: 'self.mode == ''Terminate'' ? size(self.certificateRefs)
-                          > 0 || size(self.options) > 0 : true'
-                  required:
-                  - name
-                  - protocol
-                  type: object
-                maxItems: 64
-                minItems: 1
-                type: array
-                x-kubernetes-list-map-keys:
-                - name
-                x-kubernetes-list-type: map
-                x-kubernetes-validations:
-                - message: tls must not be specified for protocols ['HTTP', 'TCP',
-                    'UDP']
-                  rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?
-                    !has(l.tls) : true)'
-                - message: tls mode must be Terminate for protocol HTTPS
-                  rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode
-                    == '''' || l.tls.mode == ''Terminate'') : true)'
-                - message: hostname must not be specified for protocols ['TCP', 'UDP']
-                  rule: 'self.all(l, l.protocol in [''TCP'', ''UDP'']  ? (!has(l.hostname)
-                    || l.hostname == '''') : true)'
-                - message: Listener name must be unique within the Gateway
-                  rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
-                - message: Combination of port, protocol and hostname must be unique
-                    for each listener
-                  rule: 'self.all(l1, !has(l1.port) || self.exists_one(l2, has(l2.port)
-                    && l1.port == l2.port && l1.protocol == l2.protocol && (has(l1.hostname)
-                    && has(l2.hostname) ? l1.hostname == l2.hostname : !has(l1.hostname)
-                    && !has(l2.hostname))))'
-              parentRef:
-                description: ParentRef references the Gateway that the listeners are
-                  attached to.
-                properties:
-                  group:
-                    default: gateway.networking.k8s.io
-                    description: Group is the group of the referent.
-                    maxLength: 253
-                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                    type: string
-                  kind:
-                    default: Gateway
-                    description: Kind is kind of the referent. For example "Gateway".
-                    maxLength: 63
-                    minLength: 1
-                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                    type: string
-                  name:
-                    description: Name is the name of the referent.
-                    maxLength: 253
-                    minLength: 1
-                    type: string
-                  namespace:
-                    description: |-
-                      Namespace is the namespace of the referent.  If not present,
-                      the namespace of the referent is assumed to be the same as
-                      the namespace of the referring object.
-                    maxLength: 63
-                    minLength: 1
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                    type: string
-                required:
-                - name
-                type: object
-            required:
-            - listeners
-            - parentRef
-            type: object
-          status:
-            default:
-              conditions:
-              - lastTransitionTime: "1970-01-01T00:00:00Z"
-                message: Waiting for controller
-                reason: Pending
-                status: Unknown
-                type: Accepted
-              - lastTransitionTime: "1970-01-01T00:00:00Z"
-                message: Waiting for controller
-                reason: Pending
-                status: Unknown
-                type: Programmed
-            description: Status defines the current state of ListenerSet.
-            properties:
-              conditions:
-                default:
-                - lastTransitionTime: "1970-01-01T00:00:00Z"
-                  message: Waiting for controller
-                  reason: Pending
-                  status: Unknown
-                  type: Accepted
-                - lastTransitionTime: "1970-01-01T00:00:00Z"
-                  message: Waiting for controller
-                  reason: Pending
-                  status: Unknown
-                  type: Programmed
-                description: |-
-                  Conditions describe the current conditions of the ListenerSet.
-
-                  Implementations MUST express ListenerSet conditions using the
-                  `ListenerSetConditionType` and `ListenerSetConditionReason`
-                  constants so that operators and tools can converge on a common
-                  vocabulary to describe ListenerSet state.
-
-                  Known condition types are:
-
-                  * "Accepted"
-                  * "Programmed"
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
-                  properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                maxItems: 8
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-              listeners:
-                description: Listeners provide status for each unique listener port
-                  defined in the Spec.
-                items:
-                  description: ListenerStatus is the status associated with a Listener.
-                  properties:
-                    attachedRoutes:
-                      description: |-
-                        AttachedRoutes represents the total number of Routes that have been
-                        successfully attached to this Listener.
-
-                        Successful attachment of a Route to a Listener is based solely on the
-                        combination of the AllowedRoutes field on the corresponding Listener
-                        and the Route's ParentRefs field. A Route is successfully attached to
-                        a Listener when it is selected by the Listener's AllowedRoutes field
-                        AND the Route has a valid ParentRef selecting the whole Gateway
-                        resource or a specific Listener as a parent resource (more detail on
-                        attachment semantics can be found in the documentation on the various
-                        Route kinds ParentRefs fields). Listener or Route status does not impact
-                        successful attachment, i.e. the AttachedRoutes field count MUST be set
-                        for Listeners with condition Accepted: false and MUST count successfully
-                        attached Routes that may themselves have Accepted: false conditions.
-
-                        Uses for this field include troubleshooting Route attachment and
-                        measuring blast radius/impact of changes to a Listener.
-                      format: int32
-                      type: integer
-                    conditions:
-                      description: Conditions describe the current condition of this
-                        listener.
-                      items:
-                        description: Condition contains details for one aspect of
-                          the current state of this API Resource.
-                        properties:
-                          lastTransitionTime:
-                            description: |-
-                              lastTransitionTime is the last time the condition transitioned from one status to another.
-                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                            format: date-time
-                            type: string
-                          message:
-                            description: |-
-                              message is a human readable message indicating details about the transition.
-                              This may be an empty string.
-                            maxLength: 32768
-                            type: string
-                          observedGeneration:
-                            description: |-
-                              observedGeneration represents the .metadata.generation that the condition was set based upon.
-                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                              with respect to the current state of the instance.
-                            format: int64
-                            minimum: 0
-                            type: integer
-                          reason:
-                            description: |-
-                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                              Producers of specific condition types may define expected values and meanings for this field,
-                              and whether the values are considered a guaranteed API.
-                              The value should be a CamelCase string.
-                              This field may not be empty.
-                            maxLength: 1024
-                            minLength: 1
-                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                            type: string
-                          status:
-                            description: status of the condition, one of True, False,
-                              Unknown.
-                            enum:
-                            - "True"
-                            - "False"
-                            - Unknown
-                            type: string
-                          type:
-                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                            maxLength: 316
-                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                            type: string
-                        required:
-                        - lastTransitionTime
-                        - message
-                        - reason
-                        - status
-                        - type
-                        type: object
-                      maxItems: 8
-                      type: array
-                      x-kubernetes-list-map-keys:
-                      - type
-                      x-kubernetes-list-type: map
-                    name:
-                      description: Name is the name of the Listener that this status
-                        corresponds to.
-                      maxLength: 253
-                      minLength: 1
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                      type: string
-                    port:
-                      description: Port is the network port the listener is configured
-                        to listen on.
-                      format: int32
-                      maximum: 65535
-                      minimum: 1
-                      type: integer
-                    supportedKinds:
-                      description: |-
-                        SupportedKinds is the list indicating the Kinds supported by this
-                        listener. This MUST represent the kinds an implementation supports for
-                        that Listener configuration.
-
-                        If kinds are specified in Spec that are not supported, they MUST NOT
-                        appear in this list and an implementation MUST set the "ResolvedRefs"
-                        condition to "False" with the "InvalidRouteKinds" reason. If both valid
-                        and invalid Route kinds are specified, the implementation MUST
-                        reference the valid Route kinds that have been specified.
-                      items:
-                        description: RouteGroupKind indicates the group and kind of
-                          a Route resource.
-                        properties:
-                          group:
-                            default: gateway.networking.k8s.io
-                            description: Group is the group of the Route.
-                            maxLength: 253
-                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                            type: string
-                          kind:
-                            description: Kind is the kind of the Route.
-                            maxLength: 63
-                            minLength: 1
-                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                            type: string
-                        required:
-                        - kind
-                        type: object
-                      maxItems: 8
-                      type: array
-                      x-kubernetes-list-type: atomic
-                  required:
-                  - attachedRoutes
-                  - conditions
-                  - name
-                  - port
-                  - supportedKinds
-                  type: object
-                maxItems: 64
-                type: array
-                x-kubernetes-list-map-keys:
-                - name
-                x-kubernetes-list-type: map
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
----
-#
 # config/crd/experimental/gateway.networking.x-k8s.io_xmeshes.yaml
 #
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.1
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.0
     gateway.networking.k8s.io/channel: experimental
   name: xmeshes.gateway.networking.x-k8s.io
 spec:

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	k8s.io/autoscaler/vertical-pod-autoscaler v1.6.0
 	k8s.io/client-go v0.35.1
 	sigs.k8s.io/controller-runtime v0.23.1
-	sigs.k8s.io/gateway-api v1.4.1
+	sigs.k8s.io/gateway-api v1.5.0
 	sigs.k8s.io/yaml v1.6.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -243,8 +243,8 @@ k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 h1:AZYQSJemyQB5eRxqcPky+/7EdBj0x
 k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
 sigs.k8s.io/controller-runtime v0.23.1 h1:TjJSM80Nf43Mg21+RCy3J70aj/W6KyvDtOlpKf+PupE=
 sigs.k8s.io/controller-runtime v0.23.1/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
-sigs.k8s.io/gateway-api v1.4.1 h1:NPxFutNkKNa8UfLd2CMlEuhIPMQgDQ6DXNKG9sHbJU8=
-sigs.k8s.io/gateway-api v1.4.1/go.mod h1:AR5RSqciWP98OPckEjOjh2XJhAe2Na4LHyXD2FUY7Qk=
+sigs.k8s.io/gateway-api v1.5.0 h1:duoo14Ky/fJXpjpmyMISE2RTBGnfCg8zICfTYLTnBJA=
+sigs.k8s.io/gateway-api v1.5.0/go.mod h1:GvCETiaMAlLym5CovLxGjS0NysqFk3+Yuq3/rh6QL2o=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/kustomize/api v0.21.1 h1:lzqbzvz2CSvsjIUZUBNFKtIMsEw7hVLJp0JeSIVmuJs=

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -45,7 +45,7 @@ import (
 // testGatewayAPIVersion must match the major.minor version of the
 // sigs.k8s.io/gateway-api dependency in go.mod. This is updated
 // automatically by the upgrade-gateway-api workflow.
-var testGatewayAPIVersion = semver.MustParse("1.4.1")
+var testGatewayAPIVersion = semver.MustParse("1.5.0")
 
 var (
 	testEnv    *envtest.Environment


### PR DESCRIPTION
Automated Gateway API upgrade to `v1.5.0`.

Release: https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.5.0

Generated by: https://github.com/matheuscscp/cloudflare-gateway-controller/actions/runs/22580452501