### PR TITLE
Make tunnel name directly reflect the gateway unique name

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,8 @@ Gateway, providing a quick view of tunnel info, conditions, and managed resource
 
 ```
 $ kubectl get cgs
-NAME         TUNNEL NAME   TUNNEL ID    DNS       SIDECAR   READY
-my-gateway   gw-a1b2c3…    abcd-1234…   Enabled   Enabled   True
+NAME         TUNNEL ID    DNS       SIDECAR   READY
+my-gateway   abcd-1234…   Enabled   Enabled   True
 ```
 
 ### Sidecar reverse proxy

--- a/api/v1/cloudflaregatewaystatus_types.go
+++ b/api/v1/cloudflaregatewaystatus_types.go
@@ -10,7 +10,7 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=cgs
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Tunnel Name",type=string,JSONPath=`.status.tunnel.name`
+// +kubebuilder:printcolumn:name="Tunnel Name",type=string,JSONPath=`.status.tunnel.name`,priority=1
 // +kubebuilder:printcolumn:name="Tunnel ID",type=string,JSONPath=`.status.tunnel.id`
 // +kubebuilder:printcolumn:name="DNS",type=string,JSONPath=`.status.conditions[?(@.type=="DNSManagement")].reason`
 // +kubebuilder:printcolumn:name="Sidecar",type=string,JSONPath=`.status.conditions[?(@.type=="Sidecar")].reason`

--- a/api/v1/meta_types.go
+++ b/api/v1/meta_types.go
@@ -4,7 +4,6 @@
 package v1
 
 import (
-	"crypto/sha256"
 	"fmt"
 	"time"
 
@@ -143,14 +142,7 @@ func GatewayResourceLabels(gwName string, component ...string) map[string]string
 
 // TunnelName returns the deterministic Cloudflare tunnel name for a Gateway.
 func TunnelName(gw *gatewayv1.Gateway) string {
-	h := sha256.New()
-	for i, p := range []string{cfClusterName, gw.Namespace, gw.Name} {
-		if i > 0 {
-			h.Write([]byte("/"))
-		}
-		h.Write([]byte(p))
-	}
-	return fmt.Sprintf("gw-%x", h.Sum(nil))
+	return fmt.Sprintf("%s/clusters/%s/namespaces/%s/gateways/%s", Group, cfClusterName, gw.Namespace, gw.Name)
 }
 
 // ReconcileInterval returns the reconciliation interval for an object

--- a/api/v1/meta_types_test.go
+++ b/api/v1/meta_types_test.go
@@ -30,12 +30,9 @@ func testGateway() *gatewayv1.Gateway {
 func TestTunnelName(t *testing.T) {
 	g := NewWithT(t)
 	gw := testGateway()
-	name := apiv1.TunnelName(gw)
-	g.Expect(name).To(HavePrefix("gw-"))
-	// Full SHA256 = 64 hex chars, "gw-" prefix = 67 chars total.
-	g.Expect(name).To(HaveLen(67))
-	// Deterministic: same cluster/ns/gw always produces the same name.
-	g.Expect(apiv1.TunnelName(gw)).To(Equal(name))
+	g.Expect(apiv1.TunnelName(gw)).To(Equal(
+		"cloudflare-gateway-controller.io/clusters/test-cluster/namespaces/my-ns/gateways/my-gw",
+	))
 }
 
 func TestGatewayResourceName(t *testing.T) {

--- a/charts/cloudflare-gateway-controller/templates/crds.yaml
+++ b/charts/cloudflare-gateway-controller/templates/crds.yaml
@@ -1376,6 +1376,7 @@ spec:
   - additionalPrinterColumns:
     - jsonPath: .status.tunnel.name
       name: Tunnel Name
+      priority: 1
       type: string
     - jsonPath: .status.tunnel.id
       name: Tunnel ID

--- a/docs/api/v1/Gateway.md
+++ b/docs/api/v1/Gateway.md
@@ -114,11 +114,11 @@ without leaking Cloudflare resources — a reborn cluster with the same
 
 | Resource                | Name                                                        |
 |-------------------------|-------------------------------------------------------------|
-| Cloudflare Tunnel       | `gw-` + hex SHA256 of `clusterName/namespace/gatewayName` (67 chars) |
+| Cloudflare Tunnel       | `cloudflare-gateway-controller.io/clusters/<clusterName>/namespaces/<namespace>/gateways/<gatewayName>` |
 | cloudflared Deployment  | `gateway-<gatewayName>-<replicaName>` (default: `primary`)  |
 | VPA (when autoscaling)  | `gateway-<gatewayName>-<replicaName>` (default: `primary`)  |
 | Tunnel token Secret     | `gateway-<gatewayName>`                                     |
-| Sidecar ConfigMap       | `gateway-<gatewayName>`                                     |
+| Routes ConfigMap        | `gateway-<gatewayName>`                                     |
 | Sidecar ServiceAccount  | `gateway-<gatewayName>`                                     |
 | Sidecar Role            | `gateway-<gatewayName>`                                     |
 | Sidecar RoleBinding     | `gateway-<gatewayName>`                                     |

--- a/docs/dev/e2e-tests.md
+++ b/docs/dev/e2e-tests.md
@@ -56,9 +56,8 @@ the header of `hack/e2e-lib.sh`.
 
 In CI, each test runs as a separate GitHub Actions matrix job with
 `KIND_CLUSTER_NAME` set to the test name. This makes each test produce unique
-Cloudflare resource names (the tunnel name includes a SHA256 of
-`clusterName/namespace/gatewayName`), so all tests safely share the same
-Cloudflare account concurrently.
+Cloudflare resource names (the tunnel name includes the cluster name), so all
+tests safely share the same Cloudflare account concurrently.
 
 ## Multi-zone tests
 

--- a/hack/e2e-lib.sh
+++ b/hack/e2e-lib.sh
@@ -92,14 +92,9 @@ export -f cfgwctl
 export CFGWCTL CREDENTIALS_FILE
 
 # cf_resource_name computes a deterministic Cloudflare resource name from the
-# given parts, matching the Go ResourceName() function: "gw-" + hex(sha256(part1/part2/...)).
+# given parts, matching the Go TunnelName() function.
 cf_resource_name() {
-    local input=""
-    for part in "$@"; do
-        [ -n "$input" ] && input+="/"
-        input+="$part"
-    done
-    echo -n "gw-$(printf '%s' "$input" | sha256sum | cut -d' ' -f1)"
+    echo -n "cloudflare-gateway-controller.io/clusters/$1/namespaces/$2/gateways/$3"
 }
 export -f cf_resource_name
 

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -645,7 +645,7 @@ func waitForGatewayClassReady(g Gomega, gc *gatewayv1.GatewayClass) {
 		ready := conditions.Find(result.Status.Conditions, apiv1.ConditionReady)
 		g.Expect(ready).NotTo(BeNil())
 		g.Expect(ready.Status).To(Equal(metav1.ConditionTrue))
-	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+	}).WithTimeout(30 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
 }
 
 func waitForGatewayProgrammed(g Gomega, gw *gatewayv1.Gateway) {
@@ -660,7 +660,7 @@ func waitForGatewayProgrammed(g Gomega, gw *gatewayv1.Gateway) {
 		g.Expect(result.Status.Addresses[0].Value).To(Equal(cloudflare.TunnelTarget("test-tunnel-id")))
 		g.Expect(result.Status.Addresses[0].Type).NotTo(BeNil())
 		g.Expect(*result.Status.Addresses[0].Type).To(Equal(gatewayv1.HostnameAddressType))
-	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+	}).WithTimeout(30 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
 }
 
 // findEvent returns the first events.k8s.io/v1 Event for the given object name


### PR DESCRIPTION
Now tunnel names will have the following format:

```
cloudflare-gateway-controller.io/clusters/<cluster>/namespaces/<ns>/gateways/<name>
```

Cloudflare is pretty permissive with tunnel names, tested empirically.