### PR TITLE
Upgrade Gateway API to v1.5.0

### DIFF
--- a/charts/cloudflare-gateway-controller/templates/gateway-api.yaml
+++ b/charts/cloudflare-gateway-controller/templates/gateway-api.yaml
@@ -22,9 +22,9 @@ spec:
       resources:   ["*"]
   validations:
     - expression: "object.spec.group != 'gateway.networking.k8s.io' || oldObject == null || (
-        has(object.metadata.annotations) && object.metadata.annotations.exists(k, k == 'gateway.networking.k8s.io/channel') &&
+        has(object.metadata.annotations) && object.metadata.annotations.exists(k, k == 'gateway.networking.k8s.io/channel') && 
         object.metadata.annotations['gateway.networking.k8s.io/channel'] == 'standard' ) || (
-        oldObject != null && has(oldObject.metadata.annotations) && oldObject.metadata.annotations.exists(k, k == 'gateway.networking.k8s.io/channel') &&
+        oldObject != null && has(oldObject.metadata.annotations) && oldObject.metadata.annotations.exists(k, k == 'gateway.networking.k8s.io/channel') && 
         oldObject.metadata.annotations['gateway.networking.k8s.io/channel'] == 'experimental' )"
       message: "Installing experimental CRDs on top of standard channel CRDs is prohibited by default. Uninstall ValidatingAdmissionPolicy safe-upgrades.gateway.networking.k8s.io to install experimental CRDs on top of standard channel CRDs."
       reason: Invalid
@@ -34,9 +34,7 @@ spec:
         !matches(object.metadata.annotations['gateway.networking.k8s.io/bundle-version'], 'v0'))" #TODO Kubernetes 1.37: Migrate to kubernetes semver library
       message: "Installing CRDs with version before v1.5.0 is prohibited by default. Uninstall ValidatingAdmissionPolicy safe-upgrades.gateway.networking.k8s.io to install older versions."
       reason: Invalid
-
 ---
-
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:


### PR DESCRIPTION
Automated Gateway API upgrade to `v1.5.0`.

Release: https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.5.0

Generated by: https://github.com/matheuscscp/cloudflare-gateway-controller/actions/runs/22653463117