### PR TITLE
Upgrade Gateway API to v1.5.0

### DIFF
--- a/charts/cloudflare-gateway-controller/templates/gateway-api.yaml
+++ b/charts/cloudflare-gateway-controller/templates/gateway-api.yaml
@@ -1,7 +1,7 @@
-{{- if .Values.api.enabled }}
 # Copyright 2026 Matheus Pimenta.
 # SPDX-License-Identifier: AGPL-3.0
 
+{{- if .Values.api.enabled }}
 #
 # config/crd/experimental/gateway.networking.k8s.io_vap_safeupgrades.yaml
 #


### PR DESCRIPTION
Automated Gateway API upgrade to `v1.5.0`.

Release: https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.5.0

Generated by: https://github.com/matheuscscp/cloudflare-gateway-controller/actions/runs/22671625464