### PR TITLE
Introduce support for `GRPCRoute`

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -107,6 +107,7 @@ jobs:
           - test_reconcile_gateway
           - test_rotate_gateway_token
           - test_health_url
+          - test_podinfo
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -123,6 +124,10 @@ jobs:
           container=$(docker create controller:e2e)
           docker cp "$container":/cfgwctl ./bin/cfgwctl
           docker rm "$container"
+
+      - name: Install podcli
+        if: matrix.test == 'test_podinfo'
+        run: GOBIN=$(pwd)/bin go install github.com/stefanprodan/podinfo/cmd/podcli@master
 
       - name: Write credentials
         env:

--- a/README.md
+++ b/README.md
@@ -9,29 +9,39 @@ A Kubernetes [Gateway API](https://gateway-api.sigs.k8s.io/) controller that man
 [Cloudflare Tunnels](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/)
 to expose cluster services to the internet.
 
-The controller watches `Gateway` and `HTTPRoute` resources and automatically provisions
-Cloudflare tunnels and DNS records to route external traffic to Kubernetes services — no
-public IPs or `LoadBalancer`-type Services required.
+The controller watches `Gateway`, `HTTPRoute`, and `GRPCRoute` resources and automatically
+provisions Cloudflare tunnels and DNS records to route external traffic to Kubernetes
+services — no public IPs or `LoadBalancer`-type Services required.
 
 ## How It Works
 
-A single Cloudflare tunnel handles all traffic, and DNS CNAME records point each hostname
-directly to the tunnel. Multiple HTTPRoutes can attach to the same Gateway — each hostname
-gets its own CNAME. The tunnel container embeds both cloudflared and a reverse proxy to
-route requests to the correct backend Service by hostname and path, with per-request load
-balancing through kube-proxy.
+A single Cloudflare tunnel handles all traffic, and proxied CNAME records point each hostname
+directly to the tunnel. Multiple HTTPRoutes and GRPCRoutes can attach to the same
+Gateway — each hostname gets its own CNAME. The tunnel container embeds both cloudflared
+and a reverse proxy to route requests to the correct backend Service by hostname, path,
+and protocol, with per-request load balancing through kube-proxy.
 
 ```mermaid
 flowchart LR
     C((Client))
-    C -->|app.example.com| CNA[CNAME app]
-    C -->|api.example.com| CNB[CNAME api]
-    CNA --> T[Tunnel]
-    CNB --> T
-    T --> TC[tunnel container]
-    TC --> SA[Service A]
-    TC --> SB[Service B]
+    C -->|app.example.com| CNA
+    C -->|api.example.com| CNB
+    subgraph cfe[Cloudflare edge]
+        CNA["CNAME app · L7 proxy"]
+        CNB["CNAME api · L7 proxy"]
+    end
+    CNA -->|"tunnel-uuid.cfargotunnel.com"| T
+    CNB -->|"tunnel-uuid.cfargotunnel.com"| T
+    subgraph Kubernetes
+        T[Tunnel client]
+        T -->|app.example.com| SA[Service app]
+        T -->|api.example.com| SB[Service api]
+    end
+    T -->|four HTTP/2 connections| cfe
 ```
+
+The diagram above illustrates the topology for a single Gateway resource. A cluster can
+have multiple Gateways, each will have its own tunnel client.
 
 A minimal setup needs a credentials Secret, a GatewayClass, a Gateway, and an HTTPRoute —
 no CloudflareGatewayParameters required. Credentials come from the GatewayClass
@@ -97,7 +107,11 @@ metadata:
   name: my-gateway
   namespace: default
 spec:
-  # ...
+  gatewayClassName: cloudflare
+  listeners:
+  - name: https
+    protocol: HTTPS
+    port: 443
   infrastructure:
     parametersRef:
       group: cloudflare-gateway-controller.io
@@ -116,6 +130,8 @@ spec:
         zone: us-east-1a
       - name: us-east-1b
         zone: us-east-1b
+      - name: us-east-1c
+        zone: us-east-1c
     autoscaling:
       enabled: true
     resources:
@@ -135,10 +151,10 @@ See the [CloudflareGatewayParameters](docs/api/v1/CloudflareGatewayParameters.md
 all options.
 
 **DNS:** The controller creates a CNAME record for each hostname declared in the attached
-HTTPRoutes. Each CNAME points directly to the tunnel address (`<tunnelID>.cfargotunnel.com`).
-When an HTTPRoute hostname is removed, its CNAME is deleted.
+routes (HTTPRoute and GRPCRoute). Each CNAME points directly to the tunnel address
+(`<tunnelID>.cfargotunnel.com`). When a route hostname is removed, its CNAME is deleted.
 
-**Cloudflare resources:** 1 tunnel, 1 CNAME record per HTTPRoute hostname.
+**Cloudflare resources:** 1 tunnel, 1 CNAME record per route hostname.
 
 **Kubernetes resources:** Per Gateway, the controller creates a tunnel Deployment,
 a tunnel token Secret, a routes ConfigMap, a ServiceAccount, a Role, and a RoleBinding.
@@ -211,12 +227,13 @@ with cloudflared's persistent connections. Without it, cloudflared opens a singl
 long-lived TCP connection to each backend Service, bypassing kube-proxy and pinning
 all traffic to one pod.
 
-The embedded reverse proxy receives all traffic from cloudflared, routes requests
-by hostname and path prefix to the correct backend Service, and disables HTTP
-keep-alives on egress so every request opens a fresh connection through kube-proxy
-for proper pod-level load balancing. When an HTTPRoute rule has multiple `backendRefs`
-with `weight` fields, the proxy distributes requests across backends according to
-their weights (traffic splitting). The proxy also supports
+The embedded reverse proxy receives all traffic from cloudflared and routes requests
+by hostname, path prefix, and protocol (HTTP vs gRPC) to the correct backend Service.
+HTTP requests use HTTP/1.1 with keep-alives disabled so every request opens a fresh
+connection through kube-proxy for proper pod-level load balancing. gRPC requests use
+HTTP/2 cleartext (h2c) to preserve streaming semantics. When a route rule has multiple
+`backendRefs` with `weight` fields, the proxy distributes requests across backends
+according to their weights (traffic splitting). The proxy also supports
 [session persistence](docs/api/v1/HTTPRoute.md#session-persistence) via cookie-based
 or header-based affinity to pin a client to the same backend across requests.
 

--- a/api/v1/meta_types.go
+++ b/api/v1/meta_types.go
@@ -41,6 +41,7 @@ const (
 	KindGatewayClass                = "GatewayClass"
 	KindGateway                     = "Gateway"
 	KindHTTPRoute                   = "HTTPRoute"
+	KindGRPCRoute                   = "GRPCRoute"
 	KindReferenceGrant              = "ReferenceGrant"
 	KindNamespace                   = "Namespace"
 	KindSecret                      = "Secret"

--- a/charts/cloudflare-gateway-controller/templates/clusterrole.yaml
+++ b/charts/cloudflare-gateway-controller/templates/clusterrole.yaml
@@ -128,6 +128,7 @@ rules:
   - gateway.networking.k8s.io
   resources:
   - gateways/status
+  - grpcroutes/status
   - httproutes/status
   verbs:
   - patch
@@ -135,6 +136,7 @@ rules:
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
+  - grpcroutes
   - httproutes
   verbs:
   - get

--- a/cmd/cfgwctl/test_load.go
+++ b/cmd/cfgwctl/test_load.go
@@ -23,18 +23,19 @@ import (
 
 func newTestLoadCmd() *cobra.Command {
 	var (
-		url           string
-		requests      int
-		duration      time.Duration
-		concurrency   int
-		namespace     string
-		labelSelector string
-		podPort       int
-		maxCV         float64
-		kubeconfig    string
-		backends      []string
-		tolerance     float64
-		hostname      string
+		url            string
+		requests       int
+		duration       time.Duration
+		concurrency    int
+		namespace      string
+		labelSelector  string
+		podPort        int
+		maxCV          float64
+		kubeconfig     string
+		backends       []string
+		tolerance      float64
+		hostname       string
+		minSuccessRate float64
 	)
 
 	cmd := &cobra.Command{
@@ -126,9 +127,11 @@ func newTestLoadCmd() *cobra.Command {
 				fmt.Printf("  host mismatches: %d\n", hostErrs.Load())
 			}
 
-			if got := ok2xx.Load(); got != totalSent {
-				return fmt.Errorf("expected %d 2xx responses, got %d (5xx: %d, other: %d)",
-					totalSent, got, err5xx.Load(), other.Load())
+			successRate := float64(ok2xx.Load()) / float64(totalSent)
+			fmt.Printf("  success rate: %.5f%% (min: %.5f%%)\n", successRate*100, minSuccessRate*100)
+			if successRate < minSuccessRate {
+				return fmt.Errorf("success rate %.5f%% below minimum %.5f%% (5xx: %d, other: %d, 2xx: %d/%d)",
+					successRate*100, minSuccessRate*100, err5xx.Load(), other.Load(), ok2xx.Load(), totalSent)
 			}
 
 			if hostname != "" && hostErrs.Load() > 0 {
@@ -229,6 +232,7 @@ func newTestLoadCmd() *cobra.Command {
 	cmd.Flags().Float64Var(&tolerance, "tolerance", 0.15,
 		"max deviation from expected share (0.15 = ±15%) for --backend checks")
 	cmd.Flags().StringVar(&hostname, "hostname", "", "expected Host header value in responses (optional)")
+	cmd.Flags().Float64Var(&minSuccessRate, "min-success-rate", 1.0, "minimum required success rate (e.g. 0.99999 for 5 nines)")
 	cobra.CheckErr(cmd.MarkFlagRequired("url"))
 
 	return cmd

--- a/docs/api/v1/GRPCRoute.md
+++ b/docs/api/v1/GRPCRoute.md
@@ -1,0 +1,193 @@
+# GRPCRoute
+
+The controller processes **GRPCRoute** resources attached to managed Gateways
+and sets conditions on `.status.parents` entries with
+`.controllerName: cloudflare-gateway-controller.io/controller`.
+
+This document covers only the conditions set by this controller. For the full
+GRPCRoute spec, see the
+[Gateway API documentation](https://gateway-api.sigs.k8s.io/api-types/grpcroute/).
+
+## Example
+
+The following example shows a GRPCRoute that routes gRPC traffic for
+`app.example.com` to a backend Service:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: my-grpc-route
+  namespace: default
+spec:
+  parentRefs:
+    - name: my-gateway
+  hostnames:
+    - "app.example.com"
+  rules:
+    - backendRefs:
+        - name: my-grpc-service
+          port: 9090
+```
+
+When DNS is configured in the [CloudflareGatewayParameters](CloudflareGatewayParameters.md),
+the controller creates CNAME records for each hostname in the GRPCRoute.
+
+An HTTPRoute and a GRPCRoute can share the same hostname on the same Gateway.
+The embedded reverse proxy distinguishes between them using the `Content-Type`
+header (`application/grpc` for gRPC). gRPC traffic is forwarded to backends
+using HTTP/2 cleartext (h2c).
+
+## Validations
+
+The controller validates each GRPCRoute on every reconciliation. If any
+validation fails, the GRPCRoute is rejected with `Accepted=False/UnsupportedValue`.
+
+### Unsupported fields
+
+The following fields are not supported and must not be set:
+
+- `spec.parentRefs[*].port`
+- `spec.rules[*].filters`
+- `spec.rules[*].backendRefs[*].filters`
+- `spec.rules[*].matches[*].method`
+- `spec.rules[*].matches[*].headers`
+
+### Backend references
+
+- At least one `backendRef` per rule is required.
+- Only `core` `Service` backends are supported. Other `group`/`kind`
+  combinations (e.g. custom backend resources) are rejected.
+- Multiple `backendRefs` in a single rule are supported. The embedded reverse
+  proxy distributes requests across backends according to their `weight` fields
+  (traffic splitting).
+- Cross-namespace `backendRefs` must be allowed by a `ReferenceGrant`.
+  Without one, the GRPCRoute is accepted but the condition
+  `ResolvedRefs=False/RefNotPermitted` is set.
+
+### Session persistence
+
+Session persistence pins a client to the same backend across requests. The
+configuration is the same as for [HTTPRoute](HTTPRoute.md#session-persistence).
+
+`idleTimeout` is **not supported** for header-based sessions and is rejected
+if configured with `type: Header`.
+
+### Namespace restrictions
+
+The GRPCRoute must be in a namespace allowed by the Gateway's listener
+`allowedRoutes` configuration. Routes from disallowed namespaces are
+rejected with `Accepted=False/NotAllowedByListeners`.
+
+## GRPCRoute Status
+
+### Conditions
+
+A GRPCRoute enters various states during its lifecycle, reflected as Kubernetes
+Conditions on each `.status.parents` entry. It can be
+[accepted](#accepted-grpcroute), have its
+[references resolved](#resolved-refs),
+have [DNS records applied](#dns-records-applied), or be
+[ready](#ready-grpcroute).
+
+#### Accepted GRPCRoute
+
+Standard Gateway API condition. The controller marks a GRPCRoute as _accepted_
+when it passes validation.
+
+When the GRPCRoute is accepted:
+
+- `type: Accepted`
+- `status: "True"`
+- `reason: Accepted`
+
+When the GRPCRoute is not accepted:
+
+- `type: Accepted`
+- `status: "False"`
+- `reason: NotAllowedByListeners | UnsupportedValue`
+
+Reasons for rejection:
+
+- `NotAllowedByListeners`: The GRPCRoute is in a namespace not allowed by the
+  Gateway's listener `allowedRoutes`.
+- `UnsupportedValue`: The GRPCRoute uses unsupported features (e.g. unsupported
+  match types, filters, or backendRef kinds).
+
+#### Resolved refs
+
+Standard Gateway API condition. The controller reports whether all `backendRef`
+references could be resolved.
+
+When all references are resolved:
+
+- `type: ResolvedRefs`
+- `status: "True"`
+- `reason: ResolvedRefs`
+
+When a reference cannot be resolved:
+
+- `type: ResolvedRefs`
+- `status: "False"`
+- `reason: RefNotPermitted`
+
+The `RefNotPermitted` reason indicates a cross-namespace backendRef is not
+permitted by a `ReferenceGrant`.
+
+#### DNS records applied
+
+Custom condition, not part of the Gateway API spec. Reports whether DNS CNAME
+records have been applied for the route's hostnames. This condition is only
+present when DNS management is enabled (see
+[CloudflareGatewayParameters](CloudflareGatewayParameters.md) for configuration
+details).
+
+When DNS records are applied successfully:
+
+- `type: DNSRecordsApplied`
+- `status: "True"`
+- `reason: ReconciliationSucceeded`
+
+In all-hostnames mode (default), the `message` lists all applied hostnames. In
+specific-zones mode, the `message` lists applied and skipped hostnames.
+
+When DNS record creation or update fails:
+
+- `type: DNSRecordsApplied`
+- `status: "Unknown"`
+- `reason: ProgressingWithRetry`
+
+This condition is removed from the status when DNS is disabled.
+
+#### Ready GRPCRoute
+
+Custom condition, not part of the Gateway API spec.
+[kstatus](https://github.com/kubernetes-sigs/cli-utils/blob/master/pkg/kstatus/README.md)-compatible
+condition. This condition starts from the parent Gateway's `Ready` value but may
+be downgraded to `Unknown`/`ProgressingWithRetry` when the Gateway is ready but
+a DNS error occurred for this route's hostnames.
+
+When the Gateway is ready and DNS records (if configured) applied successfully:
+
+- `type: Ready`
+- `status: "True"`
+- `reason: ReconciliationSucceeded`
+
+When the Gateway has a terminal failure:
+
+- `type: Ready`
+- `status: "False"`
+- `reason: ReconciliationFailed`
+
+When the Gateway is waiting for the Deployment:
+
+- `type: Ready`
+- `status: "Unknown"`
+- `reason: Progressing`
+
+When the Gateway is retrying after transient errors, or the Gateway is ready
+but a DNS error occurred for this route:
+
+- `type: Ready`
+- `status: "Unknown"`
+- `reason: ProgressingWithRetry`

--- a/docs/api/v1/Gateway.md
+++ b/docs/api/v1/Gateway.md
@@ -40,7 +40,7 @@ spec:
 The Gateway must have exactly one listener with `protocol: HTTPS` and
 `port: 443`. The `tls` field and hostnames on listeners are not supported.
 Cloudflare handles TLS termination; hostnames are configured on
-[HTTPRoute](HTTPRoute.md) resources instead.
+[HTTPRoute](HTTPRoute.md) and [GRPCRoute](GRPCRoute.md) resources instead.
 
 The `.spec.addresses` field is not supported and must not be set.
 
@@ -168,10 +168,10 @@ reconciliation. If any validation fails, the Gateway is rejected with
 - Cloudflare handles TLS termination, so the `tls` field must not be set.
   Rejected with `Accepted=False/ListenersNotValid`.
 - The listener `hostname` field must not be set. Hostnames are configured on
-  [HTTPRoutes](HTTPRoute.md) instead. Rejected with
-  `Accepted=False/ListenersNotValid`.
-- If `allowedRoutes.kinds` is set, it must only contain `HTTPRoute`. Other
-  kinds are rejected with `Accepted=False/ListenersNotValid`.
+  [HTTPRoutes](HTTPRoute.md) and [GRPCRoutes](GRPCRoute.md) instead. Rejected
+  with `Accepted=False/ListenersNotValid`.
+- If `allowedRoutes.kinds` is set, it must only contain `HTTPRoute` and/or
+  `GRPCRoute`. Other kinds are rejected with `Accepted=False/ListenersNotValid`.
 
 ### Addresses
 

--- a/docs/api/v1/README.md
+++ b/docs/api/v1/README.md
@@ -14,8 +14,11 @@ annotations, and conditions.
 - [Gateway](Gateway.md) — Manages a Cloudflare tunnel and its associated
   Kubernetes resources. Supports reconciliation control, on-demand
   reconciliation, and on-demand token rotation via annotations.
-- [HTTPRoute](HTTPRoute.md) — Routes traffic to backend Services by hostname
+- [HTTPRoute](HTTPRoute.md) — Routes HTTP traffic to backend Services by hostname
   and path. Supports traffic splitting, session persistence, and DNS CNAME
+  management.
+- [GRPCRoute](GRPCRoute.md) — Routes gRPC traffic to backend Services by
+  hostname. Supports traffic splitting, session persistence, and DNS CNAME
   management.
 
 ## Custom resources

--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -511,3 +511,32 @@ URL hostname is included in DNS CNAME records.
 9. Run `cfgwctl check gateway`; verify health check passes.
 10. Delete `HTTPRoute`, `Gateway` (wait for deletion), `Deployment`, `Service`,
     and `CloudflareGatewayParameters`.
+
+## test_podinfo
+
+Installs [podinfo](https://github.com/stefanprodan/podinfo) via Helm (latest
+`>=6.0.0, <7.0.0`) with an HTTPRoute, applies a separate GRPCRoute for the gRPC
+port, and runs all five `podcli check` subcommands through the Cloudflare tunnel.
+
+**Resources created:**
+- `Gateway` with bare Secret (no CGP)
+- podinfo Helm release (Deployment, Service, HTTPRoute) targeting port 9898
+- `GRPCRoute` targeting podinfo gRPC port 9999
+
+**Cloudflare resources:** 1 tunnel, 1 DNS CNAME record.
+
+**Pass criteria:**
+- All five `podcli check` subcommands succeed: `http`, `grpc`, `cert`, `tcp`, `ws`.
+
+**Steps:**
+
+1. Create `Gateway` (bare Secret); wait for Programmed.
+2. Install podinfo via Helm with HTTPRoute enabled and hostname set.
+3. Create `GRPCRoute` targeting podinfo port 9999 on the same hostname.
+4. Wait for HTTPS endpoint reachable.
+5. Run `podcli check http` against `https://<hostname>/`.
+6. Run `podcli check grpc` against `<hostname>:443` with `--service=podinfo --tls`.
+7. Run `podcli check cert` against `<hostname>`.
+8. Run `podcli check tcp` against `<hostname>:443`.
+9. Run `podcli check ws` against `wss://<hostname>/ws/echo`.
+10. Delete `GRPCRoute`, uninstall podinfo Helm release, delete `Gateway`.

--- a/hack/e2e-lib.sh
+++ b/hack/e2e-lib.sh
@@ -24,6 +24,7 @@
 IMAGE="${IMAGE:-cloudflare-gateway-controller:dev}"
 CREDENTIALS_FILE="${CREDENTIALS_FILE:-./api.token}"
 CFGWCTL="${CFGWCTL:-./bin/cfgwctl}"
+PATH="$(pwd)/bin:$PATH"
 CHART_DIR="charts/cloudflare-gateway-controller"
 RELEASE_NAME="cloudflare-gateway-controller"
 CONTROLLER_NS="cfgw-system"

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -2473,6 +2473,7 @@ EOF
         --namespace "$TEST_NS" \
         --label-selector app=rot-test \
         --max-cv 0.5 \
+        --min-success-rate 0.999 \
         --hostname "$hostname" &
     local LOAD_PID=$!
 
@@ -2712,6 +2713,96 @@ EOF
     kubectl delete cloudflaregatewayparameters hu-params -n "$TEST_NS" --ignore-not-found
 }
 
+test_podinfo() {
+    local hostname="pi-${TS: -6}.${TEST_TRAFFIC_ZONE_NAME}"
+
+    command -v podcli >/dev/null 2>&1 || fail "podcli not found in PATH"
+
+    log "Creating Gateway 'pi-gw' (bare Secret)..."
+    kubectl apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: pi-gw
+  namespace: $TEST_NS
+spec:
+  gatewayClassName: cloudflare
+  listeners:
+  - name: https
+    protocol: HTTPS
+    port: 443
+EOF
+
+    retry 60 5 kubectl wait gateway/pi-gw -n "$TEST_NS" \
+        --for=condition=Programmed --timeout=5s \
+        || fail "pi-gw did not become Programmed"
+    pass "pi-gw is Programmed"
+
+    log "Installing podinfo via Helm..."
+    helm repo add podinfo https://stefanprodan.github.io/podinfo 2>/dev/null || true
+    helm repo update podinfo
+    helm upgrade --install podinfo podinfo/podinfo \
+        --namespace "$TEST_NS" \
+        --version '>=6.0.0, <7.0.0' \
+        --set httpRoute.enabled=true \
+        --set-json "httpRoute.parentRefs=[{\"name\":\"pi-gw\"}]" \
+        --set "httpRoute.hostnames[0]=$hostname" \
+        --wait --timeout 120s
+    pass "podinfo installed"
+
+    log "Creating GRPCRoute for podinfo gRPC..."
+    kubectl apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: podinfo-grpc
+  namespace: $TEST_NS
+spec:
+  parentRefs:
+  - name: pi-gw
+  hostnames:
+  - "$hostname"
+  rules:
+  - backendRefs:
+    - name: podinfo
+      port: 9999
+EOF
+
+    wait_for_https "https://$hostname/"
+
+    log "Running podcli check http..."
+    retry 5 3 podcli check http "https://$hostname/" \
+        || fail "podcli check http failed"
+    pass "podcli check http passed"
+
+    log "Running podcli check grpc..."
+    retry 5 3 podcli check grpc "$hostname:443" --service=podinfo --tls \
+        || fail "podcli check grpc failed"
+    pass "podcli check grpc passed"
+
+    log "Running podcli check cert..."
+    retry 5 3 podcli check cert "$hostname" \
+        || fail "podcli check cert failed"
+    pass "podcli check cert passed"
+
+    log "Running podcli check tcp..."
+    retry 5 3 podcli check tcp "$hostname:443" \
+        || fail "podcli check tcp failed"
+    pass "podcli check tcp passed"
+
+    log "Running podcli check ws..."
+    retry 5 3 podcli check ws "wss://$hostname/ws/echo" \
+        || fail "podcli check ws failed"
+    pass "podcli check ws passed"
+
+    log "Cleaning up podinfo test..."
+    kubectl delete grpcroute podinfo-grpc -n "$TEST_NS"
+    helm uninstall podinfo -n "$TEST_NS"
+    kubectl delete gateway pi-gw -n "$TEST_NS"
+    retry 60 3 bash -c "! kubectl get gateway pi-gw -n '$TEST_NS' 2>/dev/null" \
+        || fail "pi-gw still exists"
+}
+
 # ─── Run ──────────────────────────────────────────────────────────────────────
 
 run_tests \
@@ -2732,4 +2823,5 @@ run_tests \
     test_resume_gateway \
     test_reconcile_gateway \
     test_rotate_gateway_token \
-    test_health_url
+    test_health_url \
+    test_podinfo

--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -106,6 +106,8 @@ type tunnelState struct {
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=referencegrants,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes/status,verbs=update;patch
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=grpcroutes,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=grpcroutes/status,verbs=update;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=create;get;list;watch;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
@@ -184,10 +186,11 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 }
 
 // reconcile orchestrates the main reconciliation loop for a Gateway:
-// ensure GatewayClass finalizer, validate, list HTTPRoutes, read credentials,
-// create Cloudflare client, filter and validate routes, ensure tunnel and
-// associated Secret/Deployment, clean up stale resources, reconcile tunnel
-// ingress and DNS, check readiness, update HTTPRoute and Gateway statuses.
+// ensure GatewayClass finalizer, validate, list routes (HTTPRoute + GRPCRoute),
+// read credentials, create Cloudflare client, filter and validate routes,
+// ensure tunnel and associated Secret/Deployment, clean up stale resources,
+// reconcile tunnel ingress and DNS, check readiness, update route and Gateway
+// statuses.
 func (r *GatewayReconciler) reconcile(ctx context.Context, gw *gatewayv1.Gateway, gc *gatewayv1.GatewayClass) (ctrl.Result, error) {
 	// Ensure GatewayClass finalizer
 	if err := r.ensureGatewayClassFinalizer(ctx, gc, gw); err != nil {
@@ -199,13 +202,30 @@ func (r *GatewayReconciler) reconcile(ctx context.Context, gw *gatewayv1.Gateway
 		return r.reconcileError(ctx, gw, err.err, err.cond)
 	}
 
-	// List all HTTPRoutes referencing this Gateway once, then reuse the list
-	// for attached route counts, ingress rules, DNS, and status updates.
-	var allRoutes gatewayv1.HTTPRouteList
-	if err := r.List(ctx, &allRoutes, client.MatchingFields{
-		indexHTTPRouteParentGateway: gw.Namespace + "/" + gw.Name,
+	// List all routes (HTTPRoute + GRPCRoute) referencing this Gateway once,
+	// then reuse the list for attached route counts, ingress rules, DNS, and
+	// status updates.
+	gwKey := gw.Namespace + "/" + gw.Name
+	var allRoutes []routeObject
+
+	var httpRoutes gatewayv1.HTTPRouteList
+	if err := r.List(ctx, &httpRoutes, client.MatchingFields{
+		indexHTTPRouteParentGateway: gwKey,
 	}); err != nil {
 		return r.reconcileError(ctx, gw, fmt.Errorf("listing HTTPRoutes: %w", err))
+	}
+	for i := range httpRoutes.Items {
+		allRoutes = append(allRoutes, &httpRouteObject{route: &httpRoutes.Items[i]})
+	}
+
+	var grpcRoutes gatewayv1.GRPCRouteList
+	if err := r.List(ctx, &grpcRoutes, client.MatchingFields{
+		indexGRPCRouteParentGateway: gwKey,
+	}); err != nil {
+		return r.reconcileError(ctx, gw, fmt.Errorf("listing GRPCRoutes: %w", err))
+	}
+	for i := range grpcRoutes.Items {
+		allRoutes = append(allRoutes, &grpcRouteObject{route: &grpcRoutes.Items[i]})
 	}
 
 	// Resolve CloudflareGatewayParameters if referenced.
@@ -248,22 +268,22 @@ func (r *GatewayReconciler) reconcile(ctx context.Context, gw *gatewayv1.Gateway
 	var changes []string
 	var errs []string
 
-	// Filter HTTPRoutes by parentRef and allowedRoutes.
-	gatewayRoutes, deniedRoutes, staleRoutes, err := listGatewayRoutes(ctx, r.Client, &allRoutes, gw)
+	// Filter routes by parentRef and allowedRoutes.
+	gatewayRoutes, deniedRoutes, staleRoutes, err := listGatewayRoutes(ctx, r.Client, allRoutes, gw)
 	if err != nil {
 		return r.reconcileError(ctx, gw, err)
 	}
 	// Remove stale status.parents entries for routes whose parentRef was removed.
 	for _, route := range staleRoutes {
 		if err := r.removeRouteStatus(ctx, gw, route); err != nil {
-			errs = append(errs, fmt.Sprintf("failed to remove stale HTTPRoute %s/%s status: %v", route.Namespace, route.Name, err))
+			errs = append(errs, fmt.Sprintf("failed to remove stale %s %s status: %v", route.routeKind(), route.key(), err))
 		}
 	}
 	// Set Accepted=False/NotAllowedByListeners on denied routes (cross-namespace
 	// route not permitted by the Gateway's listener allowedRoutes).
 	for _, route := range deniedRoutes {
 		if err := r.updateDeniedRouteStatus(ctx, gw, route); err != nil {
-			errs = append(errs, fmt.Sprintf("failed to update denied HTTPRoute %s/%s status: %v", route.Namespace, route.Name, err))
+			errs = append(errs, fmt.Sprintf("failed to update denied %s %s status: %v", route.routeKind(), route.key(), err))
 		}
 	}
 	// Reject routes where every parentRef to this Gateway specifies a
@@ -271,13 +291,13 @@ func (r *GatewayReconciler) reconcile(ctx context.Context, gw *gatewayv1.Gateway
 	matchedRoutes, noMatchErrs := r.filterNoMatchingParentRoutes(ctx, gw, gatewayRoutes)
 	errs = append(errs, noMatchErrs...)
 	// Set Accepted=False/UnsupportedValue on routes that use unsupported features.
-	var validRoutes []*gatewayv1.HTTPRoute
+	var validRoutes []routeObject
 	for _, route := range matchedRoutes {
-		if issues := validateHTTPRoute(route); len(issues) > 0 {
+		if issues := route.validate(); len(issues) > 0 {
 			msg := "Unsupported features:\n- " + strings.Join(issues, "\n- ")
 			if err := r.rejectRouteStatus(ctx, gw, route,
 				string(gatewayv1.RouteReasonUnsupportedValue), msg); err != nil {
-				errs = append(errs, fmt.Sprintf("failed to update invalid HTTPRoute %s/%s status: %v", route.Namespace, route.Name, err))
+				errs = append(errs, fmt.Sprintf("failed to update invalid %s %s status: %v", route.routeKind(), route.key(), err))
 			}
 			continue
 		}
@@ -380,15 +400,21 @@ func (r *GatewayReconciler) reconcile(ctx context.Context, gw *gatewayv1.Gateway
 	// Extract health URL hostname for DNS inclusion.
 	extraHostnames := extraHealthHostnames(params)
 
+	// Extract hostnames from all valid routes for DNS reconciliation.
+	var routeHostnames []gatewayv1.Hostname
+	for _, route := range validRoutes {
+		routeHostnames = append(routeHostnames, route.hostnames()...)
+	}
+
 	// Reconcile DNS, handling zone changes.
-	dnsResult := r.reconcileDNSWithZoneChange(ctx, tc, tunnel.id, validRoutes, dns, extraHostnames)
+	dnsResult := r.reconcileDNSWithZoneChange(ctx, tc, tunnel.id, routeHostnames, dns, extraHostnames)
 	changes = append(changes, dnsResult.changes...)
 	errs = append(errs, dnsResult.errs...)
 
 	// Check readiness of all tunnel Deployments.
 	readiness := r.checkAllDeploymentsReadiness(ctx, gw, replicas)
 
-	// Update HTTPRoute status.parents for allowed routes (after DNS and
+	// Update route status.parents for allowed routes (after DNS and
 	// Deployment checks so we can report DNS status and Gateway readiness).
 	errs = append(errs, r.updateRouteStatuses(ctx, gw, validRoutes, routeDeniedRefs, dns, dnsResult.dnsErr,
 		readiness.readyStatus, readiness.readyReason, readiness.readyMsg)...)
@@ -443,11 +469,11 @@ type dnsResult struct {
 // diffs against the desired set, so no previous-zone tracking is needed.
 func (r *GatewayReconciler) reconcileDNSWithZoneChange(
 	ctx context.Context, tc cloudflare.Client,
-	tunnelID string, validRoutes []*gatewayv1.HTTPRoute,
+	tunnelID string, routeHostnames []gatewayv1.Hostname,
 	dns dnsPolicy, extraHostnames []string,
 ) dnsResult {
 	var res dnsResult
-	dnsChanges, dnsErr := r.reconcileDNS(ctx, tc, tunnelID, dns, validRoutes, extraHostnames)
+	dnsChanges, dnsErr := r.reconcileDNS(ctx, tc, tunnelID, dns, routeHostnames, extraHostnames)
 	res.changes = append(res.changes, dnsChanges...)
 	res.dnsErr = dnsErr
 	if dnsErr != nil {
@@ -799,11 +825,11 @@ func (r *GatewayReconciler) finalize(ctx context.Context, gw *gatewayv1.Gateway,
 		}
 	}
 
-	// Remove this Gateway's entry from status.parents on all referencing HTTPRoutes.
+	// Remove this Gateway's entry from status.parents on all referencing routes.
 	if err := r.removeRouteStatuses(ctx, gw); err != nil {
-		return r.finalizeError(ctx, gw, changes, fmt.Errorf("removing HTTPRoute status entries: %w", err))
+		return r.finalizeError(ctx, gw, changes, fmt.Errorf("removing route status entries: %w", err))
 	}
-	l.V(1).Info("Removed HTTPRoute status entries")
+	l.V(1).Info("Removed route status entries")
 
 	// Remove this Gateway's finalizer from all GatewayClasses.
 	if err := r.removeGatewayClassFinalizer(ctx, gw); err != nil {

--- a/internal/controller/gateway_controller_routes_test.go
+++ b/internal/controller/gateway_controller_routes_test.go
@@ -2178,3 +2178,905 @@ func TestGatewayReconciler_HTTPRouteNoMatchingSectionName(t *testing.T) {
 		g.Expect(result.Status.Listeners[0].AttachedRoutes).To(Equal(int32(0)))
 	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
 }
+
+func TestGatewayReconciler_GRPCRouteAccepted(t *testing.T) {
+	g := NewWithT(t)
+
+	ns := createTestNamespace(g)
+	t.Cleanup(func() { _ = testClient.Delete(testCtx, ns) })
+
+	createTestSecret(g, ns.Name)
+	gc := createTestGatewayClass(g, "test-gw-class-grpc-accepted", ns.Name)
+	t.Cleanup(func() {
+		var latest gatewayv1.GatewayClass
+		if err := testClient.Get(testCtx, client.ObjectKeyFromObject(gc), &latest); err == nil {
+			_ = testClient.Delete(testCtx, &latest)
+		}
+	})
+
+	waitForGatewayClassReady(g, gc)
+
+	gw := createTestGateway(g, "test-gw-grpc", ns.Name, gc.Name)
+	t.Cleanup(func() {
+		var latest gatewayv1.Gateway
+		if err := testClient.Get(testCtx, client.ObjectKeyFromObject(gw), &latest); err == nil {
+			_ = testClient.Delete(testCtx, &latest)
+		}
+	})
+	waitForGatewayProgrammed(g, gw)
+
+	route := &gatewayv1.GRPCRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-grpcroute",
+			Namespace: ns.Name,
+		},
+		Spec: gatewayv1.GRPCRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{
+						Name: gatewayv1.ObjectName(gw.Name),
+					},
+				},
+			},
+			Hostnames: []gatewayv1.Hostname{"grpc.example.com"},
+			Rules: []gatewayv1.GRPCRouteRule{
+				{
+					BackendRefs: []gatewayv1.GRPCBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: "my-grpc-service",
+									Port: new(gatewayv1.PortNumber(9090)),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	g.Expect(testClient.Create(testCtx, route)).To(Succeed())
+	t.Cleanup(func() {
+		var latest gatewayv1.GRPCRoute
+		if err := testClient.Get(testCtx, client.ObjectKeyFromObject(route), &latest); err == nil {
+			_ = testClient.Delete(testCtx, &latest)
+		}
+	})
+
+	// Verify GRPCRoute becomes Accepted and Ready
+	routeKey := client.ObjectKeyFromObject(route)
+	g.Eventually(func(g Gomega) {
+		var result gatewayv1.GRPCRoute
+		g.Expect(testClient.Get(testCtx, routeKey, &result)).To(Succeed())
+		g.Expect(result.Status.Parents).To(HaveLen(1))
+		accepted := conditions.Find(result.Status.Parents[0].Conditions, string(gatewayv1.RouteConditionAccepted))
+		g.Expect(accepted).NotTo(BeNil())
+		g.Expect(accepted.Status).To(Equal(metav1.ConditionTrue))
+		g.Expect(accepted.Message).To(Equal("GRPCRoute is accepted"))
+
+		resolvedRefs := conditions.Find(result.Status.Parents[0].Conditions, string(gatewayv1.RouteConditionResolvedRefs))
+		g.Expect(resolvedRefs).NotTo(BeNil())
+		g.Expect(resolvedRefs.Status).To(Equal(metav1.ConditionTrue))
+
+		ready := conditions.Find(result.Status.Parents[0].Conditions, apiv1.ConditionReady)
+		g.Expect(ready).NotTo(BeNil())
+		g.Expect(ready.Status).To(Equal(metav1.ConditionTrue))
+		g.Expect(ready.Reason).To(Equal(apiv1.ReasonReconciliationSucceeded))
+	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+
+	// Verify route ConfigMap has the correct gRPC route with Protocol.
+	g.Eventually(func(g Gomega) {
+		cfg := getRouteConfig(g, gw)
+		g.Expect(cfg.Routes).To(HaveLen(1))
+		g.Expect(cfg.Routes[0].Hostname).To(Equal("grpc.example.com"))
+		g.Expect(cfg.Routes[0].Protocol).To(Equal("grpc"))
+		g.Expect(cfg.Routes[0].Owner).To(Equal(ns.Name + "/test-grpcroute"))
+		g.Expect(cfg.Routes[0].Backends).To(HaveLen(1))
+		g.Expect(cfg.Routes[0].Backends[0].Service).To(Equal("http://my-grpc-service." + ns.Name + ".svc.cluster.local:9090"))
+	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+
+	// Verify Gateway listener has AttachedRoutes=1
+	gwKey := client.ObjectKeyFromObject(gw)
+	g.Eventually(func(g Gomega) {
+		var result gatewayv1.Gateway
+		g.Expect(testClient.Get(testCtx, gwKey, &result)).To(Succeed())
+		g.Expect(result.Status.Listeners).To(HaveLen(1))
+		g.Expect(result.Status.Listeners[0].AttachedRoutes).To(Equal(int32(1)))
+	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+}
+
+func TestGatewayReconciler_GRPCRouteUnsupportedFeatures(t *testing.T) {
+	g := NewWithT(t)
+
+	ns := createTestNamespace(g)
+	t.Cleanup(func() { _ = testClient.Delete(testCtx, ns) })
+
+	createTestSecret(g, ns.Name)
+	gc := createTestGatewayClass(g, "test-gw-class-grpc-unsupported", ns.Name)
+	t.Cleanup(func() {
+		var latest gatewayv1.GatewayClass
+		if err := testClient.Get(testCtx, client.ObjectKeyFromObject(gc), &latest); err == nil {
+			_ = testClient.Delete(testCtx, &latest)
+		}
+	})
+
+	waitForGatewayClassReady(g, gc)
+
+	gw := createTestGateway(g, "test-gw-grpc-unsupported", ns.Name, gc.Name)
+	t.Cleanup(func() {
+		var latest gatewayv1.Gateway
+		if err := testClient.Get(testCtx, client.ObjectKeyFromObject(gw), &latest); err == nil {
+			_ = testClient.Delete(testCtx, &latest)
+		}
+	})
+	waitForGatewayProgrammed(g, gw)
+
+	// GRPCRoute with unsupported features: parentRef.port, method match, header match
+	portNum := gatewayv1.PortNumber(443)
+	methodType := gatewayv1.GRPCMethodMatchExact
+	svcName := "mypackage.MyService"
+	methodName := "MyMethod"
+	route := &gatewayv1.GRPCRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-grpc-unsupported",
+			Namespace: ns.Name,
+		},
+		Spec: gatewayv1.GRPCRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{
+						Name: gatewayv1.ObjectName(gw.Name),
+						Port: &portNum,
+					},
+				},
+			},
+			Hostnames: []gatewayv1.Hostname{"grpc-bad.example.com"},
+			Rules: []gatewayv1.GRPCRouteRule{
+				{
+					Matches: []gatewayv1.GRPCRouteMatch{
+						{
+							Method: &gatewayv1.GRPCMethodMatch{
+								Type:    &methodType,
+								Service: &svcName,
+								Method:  &methodName,
+							},
+							Headers: []gatewayv1.GRPCHeaderMatch{
+								{
+									Name:  "x-custom",
+									Value: "v",
+								},
+							},
+						},
+					},
+					BackendRefs: []gatewayv1.GRPCBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: "svc",
+									Port: new(gatewayv1.PortNumber(9090)),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	g.Expect(testClient.Create(testCtx, route)).To(Succeed())
+	t.Cleanup(func() {
+		var latest gatewayv1.GRPCRoute
+		if err := testClient.Get(testCtx, client.ObjectKeyFromObject(route), &latest); err == nil {
+			_ = testClient.Delete(testCtx, &latest)
+		}
+	})
+
+	// Verify GRPCRoute is rejected with UnsupportedValue
+	routeKey := client.ObjectKeyFromObject(route)
+	g.Eventually(func(g Gomega) {
+		var result gatewayv1.GRPCRoute
+		g.Expect(testClient.Get(testCtx, routeKey, &result)).To(Succeed())
+		g.Expect(result.Status.Parents).To(HaveLen(1))
+		accepted := conditions.Find(result.Status.Parents[0].Conditions, string(gatewayv1.RouteConditionAccepted))
+		g.Expect(accepted).NotTo(BeNil())
+		g.Expect(accepted.Status).To(Equal(metav1.ConditionFalse))
+		g.Expect(accepted.Reason).To(Equal(string(gatewayv1.RouteReasonUnsupportedValue)))
+		g.Expect(accepted.Message).To(ContainSubstring("spec.parentRefs[0].port is not supported"))
+		g.Expect(accepted.Message).To(ContainSubstring("spec.rules[0].matches[0].method is not supported"))
+		g.Expect(accepted.Message).To(ContainSubstring("spec.rules[0].matches[0].headers is not supported"))
+	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+}
+
+func TestGatewayReconciler_GRPCRouteDeletion(t *testing.T) {
+	g := NewWithT(t)
+
+	ns := createTestNamespace(g)
+	t.Cleanup(func() { _ = testClient.Delete(testCtx, ns) })
+
+	createTestSecret(g, ns.Name)
+	gc := createTestGatewayClass(g, "test-gw-class-grpc-delete", ns.Name)
+	t.Cleanup(func() {
+		var latest gatewayv1.GatewayClass
+		if err := testClient.Get(testCtx, client.ObjectKeyFromObject(gc), &latest); err == nil {
+			_ = testClient.Delete(testCtx, &latest)
+		}
+	})
+
+	waitForGatewayClassReady(g, gc)
+
+	gw := createTestGateway(g, "test-gw-grpc-delete", ns.Name, gc.Name)
+	t.Cleanup(func() {
+		var latest gatewayv1.Gateway
+		if err := testClient.Get(testCtx, client.ObjectKeyFromObject(gw), &latest); err == nil {
+			_ = testClient.Delete(testCtx, &latest)
+		}
+	})
+	waitForGatewayProgrammed(g, gw)
+
+	route := &gatewayv1.GRPCRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-grpc-delete",
+			Namespace: ns.Name,
+		},
+		Spec: gatewayv1.GRPCRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Name: gatewayv1.ObjectName(gw.Name)},
+				},
+			},
+			Hostnames: []gatewayv1.Hostname{"grpc-del.example.com"},
+			Rules: []gatewayv1.GRPCRouteRule{
+				{
+					BackendRefs: []gatewayv1.GRPCBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: "svc",
+									Port: new(gatewayv1.PortNumber(9090)),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	g.Expect(testClient.Create(testCtx, route)).To(Succeed())
+
+	// Wait for route to be accepted
+	routeKey := client.ObjectKeyFromObject(route)
+	g.Eventually(func(g Gomega) {
+		var result gatewayv1.GRPCRoute
+		g.Expect(testClient.Get(testCtx, routeKey, &result)).To(Succeed())
+		g.Expect(result.Status.Parents).To(HaveLen(1))
+		accepted := conditions.Find(result.Status.Parents[0].Conditions, string(gatewayv1.RouteConditionAccepted))
+		g.Expect(accepted).NotTo(BeNil())
+		g.Expect(accepted.Status).To(Equal(metav1.ConditionTrue))
+	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+
+	// Verify route is in ConfigMap
+	g.Eventually(func(g Gomega) {
+		cfg := getRouteConfig(g, gw)
+		g.Expect(cfg.Routes).To(HaveLen(1))
+		g.Expect(cfg.Routes[0].Protocol).To(Equal("grpc"))
+	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+
+	// Delete the GRPCRoute
+	g.Expect(testClient.Delete(testCtx, route)).To(Succeed())
+
+	// Wait for it to disappear
+	g.Eventually(func() bool {
+		var result gatewayv1.GRPCRoute
+		return apierrors.IsNotFound(testClient.Get(testCtx, routeKey, &result))
+	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(BeTrue())
+
+	// Verify route is removed from ConfigMap
+	g.Eventually(func(g Gomega) {
+		cfg := getRouteConfig(g, gw)
+		g.Expect(cfg.Routes).To(BeEmpty())
+	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+
+	// Verify Gateway listener has 0 attached routes
+	gwKey := client.ObjectKeyFromObject(gw)
+	g.Eventually(func(g Gomega) {
+		var result gatewayv1.Gateway
+		g.Expect(testClient.Get(testCtx, gwKey, &result)).To(Succeed())
+		g.Expect(result.Status.Listeners).To(HaveLen(1))
+		g.Expect(result.Status.Listeners[0].AttachedRoutes).To(Equal(int32(0)))
+	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+}
+
+func TestGatewayReconciler_GRPCRouteAndHTTPRouteSameHostname(t *testing.T) {
+	g := NewWithT(t)
+
+	ns := createTestNamespace(g)
+	t.Cleanup(func() { _ = testClient.Delete(testCtx, ns) })
+
+	createTestSecret(g, ns.Name)
+	gc := createTestGatewayClass(g, "test-gw-class-grpc-http-same", ns.Name)
+	t.Cleanup(func() {
+		var latest gatewayv1.GatewayClass
+		if err := testClient.Get(testCtx, client.ObjectKeyFromObject(gc), &latest); err == nil {
+			_ = testClient.Delete(testCtx, &latest)
+		}
+	})
+
+	waitForGatewayClassReady(g, gc)
+
+	gw := createTestGateway(g, "test-gw-grpc-http", ns.Name, gc.Name)
+	t.Cleanup(func() {
+		var latest gatewayv1.Gateway
+		if err := testClient.Get(testCtx, client.ObjectKeyFromObject(gw), &latest); err == nil {
+			_ = testClient.Delete(testCtx, &latest)
+		}
+	})
+	waitForGatewayProgrammed(g, gw)
+
+	// Create an HTTPRoute and a GRPCRoute on the same hostname
+	httpRoute := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-http-same",
+			Namespace: ns.Name,
+		},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Name: gatewayv1.ObjectName(gw.Name)},
+				},
+			},
+			Hostnames: []gatewayv1.Hostname{"shared.example.com"},
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: "http-svc",
+									Port: new(gatewayv1.PortNumber(8080)),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	g.Expect(testClient.Create(testCtx, httpRoute)).To(Succeed())
+	t.Cleanup(func() {
+		var latest gatewayv1.HTTPRoute
+		if err := testClient.Get(testCtx, client.ObjectKeyFromObject(httpRoute), &latest); err == nil {
+			_ = testClient.Delete(testCtx, &latest)
+		}
+	})
+
+	grpcRoute := &gatewayv1.GRPCRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-grpc-same",
+			Namespace: ns.Name,
+		},
+		Spec: gatewayv1.GRPCRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Name: gatewayv1.ObjectName(gw.Name)},
+				},
+			},
+			Hostnames: []gatewayv1.Hostname{"shared.example.com"},
+			Rules: []gatewayv1.GRPCRouteRule{
+				{
+					BackendRefs: []gatewayv1.GRPCBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: "grpc-svc",
+									Port: new(gatewayv1.PortNumber(9090)),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	g.Expect(testClient.Create(testCtx, grpcRoute)).To(Succeed())
+	t.Cleanup(func() {
+		var latest gatewayv1.GRPCRoute
+		if err := testClient.Get(testCtx, client.ObjectKeyFromObject(grpcRoute), &latest); err == nil {
+			_ = testClient.Delete(testCtx, &latest)
+		}
+	})
+
+	// Both routes accepted (no conflict — different protocols)
+	g.Eventually(func(g Gomega) {
+		var httpResult gatewayv1.HTTPRoute
+		g.Expect(testClient.Get(testCtx, client.ObjectKeyFromObject(httpRoute), &httpResult)).To(Succeed())
+		g.Expect(httpResult.Status.Parents).To(HaveLen(1))
+		accepted := conditions.Find(httpResult.Status.Parents[0].Conditions, string(gatewayv1.RouteConditionAccepted))
+		g.Expect(accepted).NotTo(BeNil())
+		g.Expect(accepted.Status).To(Equal(metav1.ConditionTrue))
+	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+
+	g.Eventually(func(g Gomega) {
+		var grpcResult gatewayv1.GRPCRoute
+		g.Expect(testClient.Get(testCtx, client.ObjectKeyFromObject(grpcRoute), &grpcResult)).To(Succeed())
+		g.Expect(grpcResult.Status.Parents).To(HaveLen(1))
+		accepted := conditions.Find(grpcResult.Status.Parents[0].Conditions, string(gatewayv1.RouteConditionAccepted))
+		g.Expect(accepted).NotTo(BeNil())
+		g.Expect(accepted.Status).To(Equal(metav1.ConditionTrue))
+	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+
+	// Verify ConfigMap has both routes (HTTP and gRPC)
+	g.Eventually(func(g Gomega) {
+		cfg := getRouteConfig(g, gw)
+		g.Expect(cfg.Routes).To(HaveLen(2))
+		var httpFound, grpcFound bool
+		for _, r := range cfg.Routes {
+			if r.Protocol == "" && r.Hostname == "shared.example.com" {
+				httpFound = true
+			}
+			if r.Protocol == "grpc" && r.Hostname == "shared.example.com" {
+				grpcFound = true
+			}
+		}
+		g.Expect(httpFound).To(BeTrue(), "expected HTTP route in config")
+		g.Expect(grpcFound).To(BeTrue(), "expected gRPC route in config")
+	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+
+	// Verify Gateway listener counts both routes
+	gwKey := client.ObjectKeyFromObject(gw)
+	g.Eventually(func(g Gomega) {
+		var result gatewayv1.Gateway
+		g.Expect(testClient.Get(testCtx, gwKey, &result)).To(Succeed())
+		g.Expect(result.Status.Listeners).To(HaveLen(1))
+		g.Expect(result.Status.Listeners[0].AttachedRoutes).To(Equal(int32(2)))
+	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+}
+
+func TestGatewayReconciler_GRPCRouteCrossNamespaceBackendGranted(t *testing.T) {
+	g := NewWithT(t)
+
+	nsA := createTestNamespace(g)
+	t.Cleanup(func() { _ = testClient.Delete(testCtx, nsA) })
+
+	nsB := createTestNamespace(g)
+	t.Cleanup(func() { _ = testClient.Delete(testCtx, nsB) })
+
+	createTestSecret(g, nsA.Name)
+	gc := createTestGatewayClass(g, "test-gw-class-grpc-xns-grant", nsA.Name)
+	t.Cleanup(func() {
+		var latest gatewayv1.GatewayClass
+		if err := testClient.Get(testCtx, client.ObjectKeyFromObject(gc), &latest); err == nil {
+			_ = testClient.Delete(testCtx, &latest)
+		}
+	})
+
+	waitForGatewayClassReady(g, gc)
+
+	gw := createTestGateway(g, "test-gw-grpc-xns-grant", nsA.Name, gc.Name)
+	t.Cleanup(func() {
+		var latest gatewayv1.Gateway
+		if err := testClient.Get(testCtx, client.ObjectKeyFromObject(gw), &latest); err == nil {
+			_ = testClient.Delete(testCtx, &latest)
+		}
+	})
+	waitForGatewayProgrammed(g, gw)
+
+	// Create ReferenceGrant in nsB allowing GRPCRoute from nsA
+	grant := &gatewayv1beta1.ReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "allow-grpc-backend",
+			Namespace: nsB.Name,
+		},
+		Spec: gatewayv1beta1.ReferenceGrantSpec{
+			From: []gatewayv1beta1.ReferenceGrantFrom{
+				{
+					Group:     gatewayv1beta1.Group(gatewayv1.GroupName),
+					Kind:      gatewayv1beta1.Kind(apiv1.KindGRPCRoute),
+					Namespace: gatewayv1beta1.Namespace(nsA.Name),
+				},
+			},
+			To: []gatewayv1beta1.ReferenceGrantTo{
+				{
+					Group: "",
+					Kind:  "Service",
+				},
+			},
+		},
+	}
+	g.Expect(testClient.Create(testCtx, grant)).To(Succeed())
+	t.Cleanup(func() { _ = testClient.Delete(testCtx, grant) })
+
+	// Create GRPCRoute with cross-namespace backendRef
+	nsBNS := gatewayv1.Namespace(nsB.Name)
+	route := &gatewayv1.GRPCRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-grpc-xns",
+			Namespace: nsA.Name,
+		},
+		Spec: gatewayv1.GRPCRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Name: gatewayv1.ObjectName(gw.Name)},
+				},
+			},
+			Hostnames: []gatewayv1.Hostname{"grpc-xns.example.com"},
+			Rules: []gatewayv1.GRPCRouteRule{
+				{
+					BackendRefs: []gatewayv1.GRPCBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name:      "xns-svc",
+									Port:      new(gatewayv1.PortNumber(9090)),
+									Namespace: &nsBNS,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	g.Expect(testClient.Create(testCtx, route)).To(Succeed())
+	t.Cleanup(func() {
+		var latest gatewayv1.GRPCRoute
+		if err := testClient.Get(testCtx, client.ObjectKeyFromObject(route), &latest); err == nil {
+			_ = testClient.Delete(testCtx, &latest)
+		}
+	})
+
+	// Verify ResolvedRefs=True (grant allows cross-namespace reference)
+	routeKey := client.ObjectKeyFromObject(route)
+	g.Eventually(func(g Gomega) {
+		var result gatewayv1.GRPCRoute
+		g.Expect(testClient.Get(testCtx, routeKey, &result)).To(Succeed())
+		g.Expect(result.Status.Parents).To(HaveLen(1))
+		resolved := conditions.Find(result.Status.Parents[0].Conditions, string(gatewayv1.RouteConditionResolvedRefs))
+		g.Expect(resolved).NotTo(BeNil())
+		g.Expect(resolved.Status).To(Equal(metav1.ConditionTrue))
+	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+
+	// Verify ConfigMap has the cross-namespace backend
+	g.Eventually(func(g Gomega) {
+		cfg := getRouteConfig(g, gw)
+		g.Expect(cfg.Routes).To(HaveLen(1))
+		g.Expect(cfg.Routes[0].Backends[0].Service).To(ContainSubstring(nsB.Name))
+	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+}
+
+func TestGatewayReconciler_GRPCRouteCrossNamespaceBackendDenied(t *testing.T) {
+	g := NewWithT(t)
+
+	nsA := createTestNamespace(g)
+	t.Cleanup(func() { _ = testClient.Delete(testCtx, nsA) })
+
+	nsB := createTestNamespace(g)
+	t.Cleanup(func() { _ = testClient.Delete(testCtx, nsB) })
+
+	createTestSecret(g, nsA.Name)
+	gc := createTestGatewayClass(g, "test-gw-class-grpc-xns-deny", nsA.Name)
+	t.Cleanup(func() {
+		var latest gatewayv1.GatewayClass
+		if err := testClient.Get(testCtx, client.ObjectKeyFromObject(gc), &latest); err == nil {
+			_ = testClient.Delete(testCtx, &latest)
+		}
+	})
+
+	waitForGatewayClassReady(g, gc)
+
+	gw := createTestGateway(g, "test-gw-grpc-xns-deny", nsA.Name, gc.Name)
+	t.Cleanup(func() {
+		var latest gatewayv1.Gateway
+		if err := testClient.Get(testCtx, client.ObjectKeyFromObject(gw), &latest); err == nil {
+			_ = testClient.Delete(testCtx, &latest)
+		}
+	})
+	waitForGatewayProgrammed(g, gw)
+
+	// No ReferenceGrant — cross-namespace reference should be denied
+	nsBNS := gatewayv1.Namespace(nsB.Name)
+	route := &gatewayv1.GRPCRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-grpc-xns-deny",
+			Namespace: nsA.Name,
+		},
+		Spec: gatewayv1.GRPCRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Name: gatewayv1.ObjectName(gw.Name)},
+				},
+			},
+			Hostnames: []gatewayv1.Hostname{"grpc-deny.example.com"},
+			Rules: []gatewayv1.GRPCRouteRule{
+				{
+					BackendRefs: []gatewayv1.GRPCBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name:      "xns-svc",
+									Port:      new(gatewayv1.PortNumber(9090)),
+									Namespace: &nsBNS,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	g.Expect(testClient.Create(testCtx, route)).To(Succeed())
+	t.Cleanup(func() {
+		var latest gatewayv1.GRPCRoute
+		if err := testClient.Get(testCtx, client.ObjectKeyFromObject(route), &latest); err == nil {
+			_ = testClient.Delete(testCtx, &latest)
+		}
+	})
+
+	// Verify ResolvedRefs=False/RefNotPermitted
+	routeKey := client.ObjectKeyFromObject(route)
+	g.Eventually(func(g Gomega) {
+		var result gatewayv1.GRPCRoute
+		g.Expect(testClient.Get(testCtx, routeKey, &result)).To(Succeed())
+		g.Expect(result.Status.Parents).To(HaveLen(1))
+		resolved := conditions.Find(result.Status.Parents[0].Conditions, string(gatewayv1.RouteConditionResolvedRefs))
+		g.Expect(resolved).NotTo(BeNil())
+		g.Expect(resolved.Status).To(Equal(metav1.ConditionFalse))
+		g.Expect(resolved.Reason).To(Equal(string(gatewayv1.RouteReasonRefNotPermitted)))
+	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+}
+
+func TestGatewayReconciler_DeletionWithGRPCRoutes(t *testing.T) {
+	g := NewWithT(t)
+
+	ns := createTestNamespace(g)
+	t.Cleanup(func() { _ = testClient.Delete(testCtx, ns) })
+
+	createTestSecret(g, ns.Name)
+	gc := createTestGatewayClass(g, "test-gw-class-grpc-gw-del", ns.Name)
+	t.Cleanup(func() {
+		var latest gatewayv1.GatewayClass
+		if err := testClient.Get(testCtx, client.ObjectKeyFromObject(gc), &latest); err == nil {
+			_ = testClient.Delete(testCtx, &latest)
+		}
+	})
+
+	waitForGatewayClassReady(g, gc)
+
+	gw := createTestGateway(g, "test-gw-grpc-gw-del", ns.Name, gc.Name)
+	waitForGatewayProgrammed(g, gw)
+
+	route := &gatewayv1.GRPCRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-grpc-gw-del",
+			Namespace: ns.Name,
+		},
+		Spec: gatewayv1.GRPCRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Name: gatewayv1.ObjectName(gw.Name)},
+				},
+			},
+			Hostnames: []gatewayv1.Hostname{"grpc-gwdel.example.com"},
+			Rules: []gatewayv1.GRPCRouteRule{
+				{
+					BackendRefs: []gatewayv1.GRPCBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: "svc",
+									Port: new(gatewayv1.PortNumber(9090)),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	g.Expect(testClient.Create(testCtx, route)).To(Succeed())
+	t.Cleanup(func() {
+		var latest gatewayv1.GRPCRoute
+		if err := testClient.Get(testCtx, client.ObjectKeyFromObject(route), &latest); err == nil {
+			_ = testClient.Delete(testCtx, &latest)
+		}
+	})
+
+	// Wait for GRPCRoute to be accepted and have status.parents entry
+	routeKey := client.ObjectKeyFromObject(route)
+	g.Eventually(func(g Gomega) {
+		var result gatewayv1.GRPCRoute
+		g.Expect(testClient.Get(testCtx, routeKey, &result)).To(Succeed())
+		g.Expect(result.Status.Parents).To(HaveLen(1))
+		accepted := conditions.Find(result.Status.Parents[0].Conditions, string(gatewayv1.RouteConditionAccepted))
+		g.Expect(accepted).NotTo(BeNil())
+		g.Expect(accepted.Status).To(Equal(metav1.ConditionTrue))
+	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+
+	// Delete the Gateway
+	g.Expect(testClient.Delete(testCtx, gw)).To(Succeed())
+
+	gwKey := client.ObjectKeyFromObject(gw)
+	g.Eventually(func() bool {
+		var result gatewayv1.Gateway
+		return apierrors.IsNotFound(testClient.Get(testCtx, gwKey, &result))
+	}).WithTimeout(30 * time.Second).WithPolling(100 * time.Millisecond).Should(BeTrue())
+
+	// Verify GRPCRoute status.parents entry was removed by finalization
+	g.Eventually(func(g Gomega) {
+		var result gatewayv1.GRPCRoute
+		g.Expect(testClient.Get(testCtx, routeKey, &result)).To(Succeed())
+		g.Expect(result.Status.Parents).To(BeEmpty())
+	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+}
+
+func TestGatewayReconciler_GRPCRouteListenerKindRestriction(t *testing.T) {
+	g := NewWithT(t)
+
+	ns := createTestNamespace(g)
+	t.Cleanup(func() { _ = testClient.Delete(testCtx, ns) })
+
+	createTestSecret(g, ns.Name)
+	gc := createTestGatewayClass(g, "test-gw-class-grpc-kind-restrict", ns.Name)
+	t.Cleanup(func() {
+		var latest gatewayv1.GatewayClass
+		if err := testClient.Get(testCtx, client.ObjectKeyFromObject(gc), &latest); err == nil {
+			_ = testClient.Delete(testCtx, &latest)
+		}
+	})
+
+	waitForGatewayClassReady(g, gc)
+
+	// Gateway with listener that only allows HTTPRoute (not GRPCRoute)
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gw-grpc-kind-restrict",
+			Namespace: ns.Name,
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: gatewayv1.ObjectName(gc.Name),
+			Listeners: []gatewayv1.Listener{
+				{
+					Name:     "https",
+					Protocol: gatewayv1.HTTPSProtocolType,
+					Port:     443,
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Kinds: []gatewayv1.RouteGroupKind{
+							{Kind: apiv1.KindHTTPRoute},
+						},
+					},
+				},
+			},
+		},
+	}
+	g.Expect(testClient.Create(testCtx, gw)).To(Succeed())
+	t.Cleanup(func() {
+		var latest gatewayv1.Gateway
+		if err := testClient.Get(testCtx, client.ObjectKeyFromObject(gw), &latest); err == nil {
+			_ = testClient.Delete(testCtx, &latest)
+		}
+	})
+	waitForGatewayProgrammed(g, gw)
+
+	// Create a GRPCRoute — should be rejected since listener only allows HTTPRoute
+	route := &gatewayv1.GRPCRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-grpc-kind-restrict",
+			Namespace: ns.Name,
+		},
+		Spec: gatewayv1.GRPCRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Name: gatewayv1.ObjectName(gw.Name)},
+				},
+			},
+			Hostnames: []gatewayv1.Hostname{"grpc-restrict.example.com"},
+			Rules: []gatewayv1.GRPCRouteRule{
+				{
+					BackendRefs: []gatewayv1.GRPCBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: "svc",
+									Port: new(gatewayv1.PortNumber(9090)),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	g.Expect(testClient.Create(testCtx, route)).To(Succeed())
+	t.Cleanup(func() {
+		var latest gatewayv1.GRPCRoute
+		if err := testClient.Get(testCtx, client.ObjectKeyFromObject(route), &latest); err == nil {
+			_ = testClient.Delete(testCtx, &latest)
+		}
+	})
+
+	// Verify GRPCRoute is rejected: NoMatchingParent (listener doesn't allow GRPCRoute)
+	routeKey := client.ObjectKeyFromObject(route)
+	g.Eventually(func(g Gomega) {
+		var result gatewayv1.GRPCRoute
+		g.Expect(testClient.Get(testCtx, routeKey, &result)).To(Succeed())
+		g.Expect(result.Status.Parents).To(HaveLen(1))
+		accepted := conditions.Find(result.Status.Parents[0].Conditions, string(gatewayv1.RouteConditionAccepted))
+		g.Expect(accepted).NotTo(BeNil())
+		g.Expect(accepted.Status).To(Equal(metav1.ConditionFalse))
+		g.Expect(accepted.Reason).To(Equal(string(gatewayv1.RouteReasonNoMatchingParent)))
+	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+
+	// Verify Gateway listener has 0 attached routes (GRPCRoute not counted)
+	gwKey := client.ObjectKeyFromObject(gw)
+	g.Eventually(func(g Gomega) {
+		var result gatewayv1.Gateway
+		g.Expect(testClient.Get(testCtx, gwKey, &result)).To(Succeed())
+		g.Expect(result.Status.Listeners).To(HaveLen(1))
+		g.Expect(result.Status.Listeners[0].AttachedRoutes).To(Equal(int32(0)))
+	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+}
+
+func TestGatewayReconciler_GRPCRouteNoBackends(t *testing.T) {
+	g := NewWithT(t)
+
+	ns := createTestNamespace(g)
+	t.Cleanup(func() { _ = testClient.Delete(testCtx, ns) })
+
+	createTestSecret(g, ns.Name)
+	gc := createTestGatewayClass(g, "test-gw-class-grpc-nobackend", ns.Name)
+	t.Cleanup(func() {
+		var latest gatewayv1.GatewayClass
+		if err := testClient.Get(testCtx, client.ObjectKeyFromObject(gc), &latest); err == nil {
+			_ = testClient.Delete(testCtx, &latest)
+		}
+	})
+
+	waitForGatewayClassReady(g, gc)
+
+	gw := createTestGateway(g, "test-gw-grpc-nobackend", ns.Name, gc.Name)
+	t.Cleanup(func() {
+		var latest gatewayv1.Gateway
+		if err := testClient.Get(testCtx, client.ObjectKeyFromObject(gw), &latest); err == nil {
+			_ = testClient.Delete(testCtx, &latest)
+		}
+	})
+	waitForGatewayProgrammed(g, gw)
+
+	// GRPCRoute with zero backendRefs
+	route := &gatewayv1.GRPCRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-grpc-nobackend",
+			Namespace: ns.Name,
+		},
+		Spec: gatewayv1.GRPCRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Name: gatewayv1.ObjectName(gw.Name)},
+				},
+			},
+			Hostnames: []gatewayv1.Hostname{"grpc-nobackend.example.com"},
+			Rules: []gatewayv1.GRPCRouteRule{
+				{
+					BackendRefs: []gatewayv1.GRPCBackendRef{},
+				},
+			},
+		},
+	}
+	g.Expect(testClient.Create(testCtx, route)).To(Succeed())
+	t.Cleanup(func() {
+		var latest gatewayv1.GRPCRoute
+		if err := testClient.Get(testCtx, client.ObjectKeyFromObject(route), &latest); err == nil {
+			_ = testClient.Delete(testCtx, &latest)
+		}
+	})
+
+	routeKey := client.ObjectKeyFromObject(route)
+	g.Eventually(func(g Gomega) {
+		var result gatewayv1.GRPCRoute
+		g.Expect(testClient.Get(testCtx, routeKey, &result)).To(Succeed())
+		g.Expect(result.Status.Parents).To(HaveLen(1))
+		accepted := conditions.Find(result.Status.Parents[0].Conditions, string(gatewayv1.RouteConditionAccepted))
+		g.Expect(accepted).NotTo(BeNil())
+		g.Expect(accepted.Status).To(Equal(metav1.ConditionFalse))
+		g.Expect(accepted.Reason).To(Equal(string(gatewayv1.RouteReasonUnsupportedValue)))
+		g.Expect(accepted.Message).To(ContainSubstring("at least one backend is required"))
+	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+}

--- a/internal/controller/gateway_controller_test.go
+++ b/internal/controller/gateway_controller_test.go
@@ -506,7 +506,7 @@ func TestGatewayReconciler_AllowedRoutesKinds(t *testing.T) {
 		g.Expect(accepted).NotTo(BeNil())
 		g.Expect(accepted.Status).To(Equal(metav1.ConditionFalse))
 		g.Expect(accepted.Reason).To(Equal(string(gatewayv1.GatewayReasonListenersNotValid)))
-		g.Expect(accepted.Message).To(ContainSubstring("Only HTTPRoute kind is supported"))
+		g.Expect(accepted.Message).To(ContainSubstring("Only HTTPRoute and GRPCRoute kinds are supported"))
 	}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
 }
 

--- a/internal/controller/gateway_dns.go
+++ b/internal/controller/gateway_dns.go
@@ -29,13 +29,13 @@ func (d dnsPolicy) allZones() bool { return d.enabled && len(d.zones) == 0 }
 
 // reconcileDNS reconciles DNS CNAME records for the Gateway. It lists all
 // records pointing to the tunnel across all account zones, computes the
-// desired set from routes + configured zones + extra hostnames, and diffs:
-// creating missing records and deleting stale ones. When dns is disabled,
-// all records are deleted.
+// desired set from route hostnames + configured zones + extra hostnames, and
+// diffs: creating missing records and deleting stale ones. When dns is
+// disabled, all records are deleted.
 func (r *GatewayReconciler) reconcileDNS(
 	ctx context.Context, tc cloudflare.Client,
 	tunnelID string, dns dnsPolicy,
-	routes []*gatewayv1.HTTPRoute,
+	routeHostnames []gatewayv1.Hostname,
 	extraHostnames []string,
 ) ([]string, *string) {
 	l := log.FromContext(ctx)
@@ -82,18 +82,16 @@ func (r *GatewayReconciler) reconcileDNS(
 
 	if dns.allZones() {
 		// All-zones mode: resolve each hostname's zone dynamically.
-		for _, route := range routes {
-			for _, h := range route.Spec.Hostnames {
-				hostname := string(h)
-				zoneID, err := tc.FindZoneIDByHostname(ctx, hostname)
-				if err != nil {
-					// Skip hostnames whose zone cannot be resolved — they may
-					// not belong to any zone in the account.
-					l.V(1).Info("Skipping hostname: zone lookup failed", "hostname", hostname, "error", err)
-					continue
-				}
-				desired[hostname] = zoneID
+		for _, h := range routeHostnames {
+			hostname := string(h)
+			zoneID, err := tc.FindZoneIDByHostname(ctx, hostname)
+			if err != nil {
+				// Skip hostnames whose zone cannot be resolved — they may
+				// not belong to any zone in the account.
+				l.V(1).Info("Skipping hostname: zone lookup failed", "hostname", hostname, "error", err)
+				continue
 			}
+			desired[hostname] = zoneID
 		}
 		for _, hostname := range extraHostnames {
 			zoneID, err := tc.FindZoneIDByHostname(ctx, hostname)
@@ -114,13 +112,11 @@ func (r *GatewayReconciler) reconcileDNS(
 			}
 			zoneMap[zoneName] = zoneID
 		}
-		for _, route := range routes {
-			for _, h := range route.Spec.Hostnames {
-				hostname := string(h)
-				for _, zoneName := range dns.zones {
-					if hostnameInZone(hostname, zoneName) {
-						desired[hostname] = zoneMap[zoneName]
-					}
+		for _, h := range routeHostnames {
+			hostname := string(h)
+			for _, zoneName := range dns.zones {
+				if hostnameInZone(hostname, zoneName) {
+					desired[hostname] = zoneMap[zoneName]
 				}
 			}
 		}

--- a/internal/controller/gateway_manager.go
+++ b/internal/controller/gateway_manager.go
@@ -72,6 +72,10 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(mapHTTPRouteToGateway),
 			builder.WithPredicates(predicates.Debug(apiv1.KindHTTPRoute,
 				predicate.GenerationChangedPredicate{}))).
+		Watches(&gatewayv1.GRPCRoute{},
+			handler.EnqueueRequestsFromMapFunc(mapGRPCRouteToGateway),
+			builder.WithPredicates(predicates.Debug(apiv1.KindGRPCRoute,
+				predicate.GenerationChangedPredicate{}))).
 		Watches(&gatewayv1beta1.ReferenceGrant{},
 			handler.EnqueueRequestsFromMapFunc(r.mapReferenceGrantToGateway),
 			builder.WithPredicates(predicates.Debug(apiv1.KindReferenceGrant,
@@ -135,6 +139,52 @@ func mapHTTPRouteToGateway(_ context.Context, obj client.Object) []reconcile.Req
 	return requests
 }
 
+// mapGRPCRouteToGateway maps a GRPCRoute event to reconcile requests for its
+// parent Gateways (from spec.parentRefs) and any Gateways that have existing
+// status.parents entries managed by our controller.
+func mapGRPCRouteToGateway(_ context.Context, obj client.Object) []reconcile.Request {
+	route, ok := obj.(*gatewayv1.GRPCRoute)
+	if !ok {
+		return nil
+	}
+	seen := make(map[types.NamespacedName]struct{})
+	var requests []reconcile.Request
+	for _, ref := range route.Spec.ParentRefs {
+		if ref.Group != nil && *ref.Group != gatewayv1.Group(gatewayv1.GroupName) {
+			continue
+		}
+		if ref.Kind != nil && *ref.Kind != gatewayv1.Kind(apiv1.KindGateway) {
+			continue
+		}
+		ns := route.Namespace
+		if ref.Namespace != nil {
+			ns = string(*ref.Namespace)
+		}
+		key := types.NamespacedName{Namespace: ns, Name: string(ref.Name)}
+		if _, ok := seen[key]; !ok {
+			seen[key] = struct{}{}
+			requests = append(requests, reconcile.Request{NamespacedName: key})
+		}
+	}
+	for _, s := range route.Status.Parents {
+		if s.ControllerName != apiv1.ControllerName {
+			continue
+		}
+		if s.ParentRef.Namespace == nil {
+			continue
+		}
+		key := types.NamespacedName{
+			Namespace: string(*s.ParentRef.Namespace),
+			Name:      string(s.ParentRef.Name),
+		}
+		if _, ok := seen[key]; !ok {
+			seen[key] = struct{}{}
+			requests = append(requests, reconcile.Request{NamespacedName: key})
+		}
+	}
+	return requests
+}
+
 // mapGatewayClassToGateway maps a GatewayClass event to reconcile requests for
 // all Gateways that reference it via spec.gatewayClassName.
 func (r *GatewayReconciler) mapGatewayClassToGateway(ctx context.Context, obj client.Object) []reconcile.Request {
@@ -155,8 +205,8 @@ func (r *GatewayReconciler) mapGatewayClassToGateway(ctx context.Context, obj cl
 }
 
 // mapReferenceGrantToGateway maps a ReferenceGrant event to reconcile requests
-// for Gateways whose attached HTTPRoutes have cross-namespace backend Service
-// references affected by the grant. The grant's from entries (Kind=HTTPRoute)
+// for Gateways whose attached routes (HTTPRoute or GRPCRoute) have cross-namespace
+// backend Service references affected by the grant. The grant's from entries
 // combined with the grant's own namespace (where the Service lives) form exact
 // index queries to find the affected routes, whose parentRefs yield the Gateways.
 func (r *GatewayReconciler) mapReferenceGrantToGateway(ctx context.Context, obj client.Object) []reconcile.Request {
@@ -177,43 +227,62 @@ func (r *GatewayReconciler) mapReferenceGrantToGateway(ctx context.Context, obj 
 		return nil
 	}
 
-	// For each "from" entry with Kind=HTTPRoute, query the index to find
-	// routes in that namespace with cross-namespace backends in the grant's
-	// namespace, then collect their parent Gateways.
+	// For each "from" entry with Kind=HTTPRoute or Kind=GRPCRoute, query the
+	// index to find routes in that namespace with cross-namespace backends in
+	// the grant's namespace, then collect their parent Gateways.
 	seen := make(map[types.NamespacedName]struct{})
 	var requests []reconcile.Request
+
+	collectParentGateways := func(parentRefs []gatewayv1.ParentReference, routeNamespace string) {
+		for _, ref := range parentRefs {
+			if ref.Group != nil && *ref.Group != gatewayv1.Group(gatewayv1.GroupName) {
+				continue
+			}
+			if ref.Kind != nil && *ref.Kind != gatewayv1.Kind(apiv1.KindGateway) {
+				continue
+			}
+			ns := routeNamespace
+			if ref.Namespace != nil {
+				ns = string(*ref.Namespace)
+			}
+			key := types.NamespacedName{Namespace: ns, Name: string(ref.Name)}
+			if _, ok := seen[key]; !ok {
+				seen[key] = struct{}{}
+				requests = append(requests, reconcile.Request{NamespacedName: key})
+			}
+		}
+	}
+
 	for _, from := range grant.Spec.From {
-		if from.Group != gatewayv1beta1.Group(gatewayv1.GroupName) ||
-			from.Kind != gatewayv1beta1.Kind(apiv1.KindHTTPRoute) {
+		if from.Group != gatewayv1beta1.Group(gatewayv1.GroupName) {
 			continue
 		}
+		indexKey := string(from.Namespace) + "/" + grant.Namespace
 
-		var routes gatewayv1.HTTPRouteList
-		if err := r.List(ctx, &routes, client.MatchingFields{
-			indexHTTPRouteBackendServiceNS: string(from.Namespace) + "/" + grant.Namespace,
-		}); err != nil {
-			log.FromContext(ctx).Error(err, "failed to list HTTPRoutes for ReferenceGrant",
-				"fromNamespace", from.Namespace, "grantNamespace", grant.Namespace)
-			continue
-		}
-
-		for i := range routes.Items {
-			for _, ref := range routes.Items[i].Spec.ParentRefs {
-				if ref.Group != nil && *ref.Group != gatewayv1.Group(gatewayv1.GroupName) {
-					continue
-				}
-				if ref.Kind != nil && *ref.Kind != gatewayv1.Kind(apiv1.KindGateway) {
-					continue
-				}
-				ns := routes.Items[i].Namespace
-				if ref.Namespace != nil {
-					ns = string(*ref.Namespace)
-				}
-				key := types.NamespacedName{Namespace: ns, Name: string(ref.Name)}
-				if _, ok := seen[key]; !ok {
-					seen[key] = struct{}{}
-					requests = append(requests, reconcile.Request{NamespacedName: key})
-				}
+		switch string(from.Kind) {
+		case apiv1.KindHTTPRoute:
+			var routes gatewayv1.HTTPRouteList
+			if err := r.List(ctx, &routes, client.MatchingFields{
+				indexHTTPRouteBackendServiceNS: indexKey,
+			}); err != nil {
+				log.FromContext(ctx).Error(err, "failed to list HTTPRoutes for ReferenceGrant",
+					"fromNamespace", from.Namespace, "grantNamespace", grant.Namespace)
+				continue
+			}
+			for i := range routes.Items {
+				collectParentGateways(routes.Items[i].Spec.ParentRefs, routes.Items[i].Namespace)
+			}
+		case apiv1.KindGRPCRoute:
+			var routes gatewayv1.GRPCRouteList
+			if err := r.List(ctx, &routes, client.MatchingFields{
+				indexGRPCRouteBackendServiceNS: indexKey,
+			}); err != nil {
+				log.FromContext(ctx).Error(err, "failed to list GRPCRoutes for ReferenceGrant",
+					"fromNamespace", from.Namespace, "grantNamespace", grant.Namespace)
+				continue
+			}
+			for i := range routes.Items {
+				collectParentGateways(routes.Items[i].Spec.ParentRefs, routes.Items[i].Namespace)
 			}
 		}
 	}

--- a/internal/controller/gateway_routes.go
+++ b/internal/controller/gateway_routes.go
@@ -31,7 +31,7 @@ type gatewayValidationError struct {
 	cond metav1.Condition
 }
 
-// routeConditions holds the pre-computed condition values for an HTTPRoute's
+// routeConditions holds the pre-computed condition values for a route's
 // status.parents entry (ResolvedRefs, DNS, Ready).
 type routeConditions struct {
 	resolvedRefsStatus                  metav1.ConditionStatus
@@ -86,7 +86,7 @@ func validateGateway(gw *gatewayv1.Gateway) *gatewayValidationError {
 
 	if l.Hostname != nil {
 		return rejectedCond(gatewayv1.GatewayReasonListenersNotValid,
-			"spec.listeners[0].hostname is not supported; use HTTPRoute hostnames instead")
+			"spec.listeners[0].hostname is not supported; use route hostnames instead")
 	}
 
 	if l.AllowedRoutes != nil && len(l.AllowedRoutes.Kinds) > 0 {
@@ -95,8 +95,8 @@ func validateGateway(gw *gatewayv1.Gateway) *gatewayValidationError {
 			if k.Group != nil {
 				group = *k.Group
 			}
-			if group != gatewayv1.Group(gatewayv1.GroupName) || string(k.Kind) != apiv1.KindHTTPRoute {
-				msg := fmt.Sprintf("Only HTTPRoute kind is supported in spec.listeners[0].allowedRoutes.kinds, got %s/%s", group, k.Kind)
+			if group != gatewayv1.Group(gatewayv1.GroupName) || (string(k.Kind) != apiv1.KindHTTPRoute && string(k.Kind) != apiv1.KindGRPCRoute) {
+				msg := fmt.Sprintf("Only HTTPRoute and GRPCRoute kinds are supported in spec.listeners[0].allowedRoutes.kinds, got %s/%s", group, k.Kind)
 				return rejectedCond(gatewayv1.GatewayReasonListenersNotValid, msg)
 			}
 		}
@@ -210,49 +210,47 @@ func validateParameters(params *apiv1.CloudflareGatewayParameters) *gatewayValid
 	return nil
 }
 
-// listGatewayRoutes filters non-deleting HTTPRoutes from the pre-fetched list that
+// listGatewayRoutes filters non-deleting routes from the pre-fetched list that
 // reference the given Gateway via spec.parentRefs. Cross-namespace routes are only
 // included if the Gateway's listener allowedRoutes configuration permits the route's
 // namespace. Denied routes are returned separately so the caller can report them.
 // Routes that appear in allRoutes but do not have a matching parentRef (e.g. stale
 // status.parents entries from a previous parentRef) are returned as stale.
-func listGatewayRoutes(ctx context.Context, r client.Client, allRoutes *gatewayv1.HTTPRouteList, gw *gatewayv1.Gateway) (allowed, denied, stale []*gatewayv1.HTTPRoute, err error) {
-	for i := range allRoutes.Items {
-		hr := &allRoutes.Items[i]
-
-		if !hr.DeletionTimestamp.IsZero() {
+func listGatewayRoutes(ctx context.Context, r client.Client, allRoutes []routeObject, gw *gatewayv1.Gateway) (allowed, denied, stale []routeObject, err error) {
+	for _, route := range allRoutes {
+		if !route.obj().GetDeletionTimestamp().IsZero() {
 			continue
 		}
 
 		// Check if the route actually has a parentRef to this Gateway.
 		hasParentRef := false
-		for _, ref := range hr.Spec.ParentRefs {
-			if parentRefMatches(ref, gw, hr.Namespace) {
+		for _, ref := range route.parentRefs() {
+			if parentRefMatches(ref, gw, route.obj().GetNamespace()) {
 				hasParentRef = true
 				break
 			}
 		}
 		if !hasParentRef {
 			// Route appeared in the index via a stale status.parents entry.
-			stale = append(stale, hr)
+			stale = append(stale, route)
 			continue
 		}
 
-		ok, checkErr := routeNamespaceAllowed(ctx, r, gw, hr.Namespace)
+		ok, checkErr := routeNamespaceAllowed(ctx, r, gw, route.obj().GetNamespace())
 		if checkErr != nil {
-			return nil, nil, nil, fmt.Errorf("checking allowedRoutes for HTTPRoute %s/%s: %w", hr.Namespace, hr.Name, checkErr)
+			return nil, nil, nil, fmt.Errorf("checking allowedRoutes for %s %s/%s: %w", route.routeKind(), route.obj().GetNamespace(), route.obj().GetName(), checkErr)
 		}
 		if !ok {
-			denied = append(denied, hr)
+			denied = append(denied, route)
 			continue
 		}
-		allowed = append(allowed, hr)
+		allowed = append(allowed, route)
 	}
-	slices.SortFunc(allowed, func(a, b *gatewayv1.HTTPRoute) int {
-		return strings.Compare(a.Namespace+"/"+a.Name, b.Namespace+"/"+b.Name)
+	slices.SortFunc(allowed, func(a, b routeObject) int {
+		return strings.Compare(a.obj().GetNamespace()+"/"+a.obj().GetName(), b.obj().GetNamespace()+"/"+b.obj().GetName())
 	})
-	slices.SortFunc(denied, func(a, b *gatewayv1.HTTPRoute) int {
-		return strings.Compare(a.Namespace+"/"+a.Name, b.Namespace+"/"+b.Name)
+	slices.SortFunc(denied, func(a, b routeObject) int {
+		return strings.Compare(a.obj().GetNamespace()+"/"+a.obj().GetName(), b.obj().GetNamespace()+"/"+b.obj().GetName())
 	})
 	return allowed, denied, stale, nil
 }
@@ -304,6 +302,10 @@ func buildListenerStatuses(gw *gatewayv1.Gateway, attachedRoutes map[gatewayv1.S
 				{
 					Group: new(gatewayv1.Group(gatewayv1.GroupVersion.Group)),
 					Kind:  apiv1.KindHTTPRoute,
+				},
+				{
+					Group: new(gatewayv1.Group(gatewayv1.GroupVersion.Group)),
+					Kind:  apiv1.KindGRPCRoute,
 				},
 			},
 			AttachedRoutes: attachedRoutes[l.Name],
@@ -401,17 +403,18 @@ func addressesChanged(existing, desired []gatewayv1.GatewayStatusAddress) bool {
 }
 
 // filterNoMatchingParentRoutes rejects routes where every parentRef to the
-// Gateway specifies a sectionName that doesn't match any listener, returning
-// the remaining routes and any non-fatal errors from status patches.
-func (r *GatewayReconciler) filterNoMatchingParentRoutes(ctx context.Context, gw *gatewayv1.Gateway, routes []*gatewayv1.HTTPRoute) ([]*gatewayv1.HTTPRoute, []string) {
-	var matched []*gatewayv1.HTTPRoute
+// Gateway specifies a sectionName that doesn't match any listener (or the
+// listener doesn't allow the route's kind), returning the remaining routes
+// and any non-fatal errors from status patches.
+func (r *GatewayReconciler) filterNoMatchingParentRoutes(ctx context.Context, gw *gatewayv1.Gateway, routes []routeObject) ([]routeObject, []string) {
+	var matched []routeObject
 	var errs []string
 	for _, route := range routes {
 		if !hasMatchingListener(gw, route) {
 			msg := fmt.Sprintf("No listener matches the sectionName(s) in parentRefs for Gateway %s/%s", gw.Namespace, gw.Name)
 			if err := r.rejectRouteStatus(ctx, gw, route,
 				string(gatewayv1.RouteReasonNoMatchingParent), msg); err != nil {
-				errs = append(errs, fmt.Sprintf("failed to update no-matching-parent HTTPRoute %s/%s status: %v", route.Namespace, route.Name, err))
+				errs = append(errs, fmt.Sprintf("failed to update no-matching-parent %s %s status: %v", route.routeKind(), route.key(), err))
 			}
 			continue
 		}
@@ -421,19 +424,24 @@ func (r *GatewayReconciler) filterNoMatchingParentRoutes(ctx context.Context, gw
 }
 
 // hasMatchingListener reports whether at least one parentRef targeting the
-// given Gateway has a valid sectionName (nil or matching an actual listener).
-// Routes where every parentRef specifies a non-existent sectionName should be
-// rejected with RouteReasonNoMatchingParent.
-func hasMatchingListener(gw *gatewayv1.Gateway, route *gatewayv1.HTTPRoute) bool {
-	for _, ref := range route.Spec.ParentRefs {
-		if !parentRefMatches(ref, gw, route.Namespace) {
+// given Gateway has a valid sectionName (nil or matching an actual listener)
+// and the listener allows the route's kind. Routes where no parentRef matches
+// should be rejected with RouteReasonNoMatchingParent.
+func hasMatchingListener(gw *gatewayv1.Gateway, route routeObject) bool {
+	for _, ref := range route.parentRefs() {
+		if !parentRefMatches(ref, gw, route.obj().GetNamespace()) {
 			continue
 		}
 		if ref.SectionName == nil {
-			return true
+			for _, l := range gw.Spec.Listeners {
+				if listenerAllowsKind(l, route.routeKind()) {
+					return true
+				}
+			}
+			continue
 		}
 		for _, l := range gw.Spec.Listeners {
-			if l.Name == *ref.SectionName {
+			if l.Name == *ref.SectionName && listenerAllowsKind(l, route.routeKind()) {
 				return true
 			}
 		}
@@ -441,27 +449,28 @@ func hasMatchingListener(gw *gatewayv1.Gateway, route *gatewayv1.HTTPRoute) bool
 	return false
 }
 
-// countAttachedRoutes counts the number of allowed HTTPRoutes attached to each
-// listener of the given Gateway. Routes without a sectionName count toward all listeners.
-func countAttachedRoutes(routes []*gatewayv1.HTTPRoute, gw *gatewayv1.Gateway) map[gatewayv1.SectionName]int32 {
+// countAttachedRoutes counts the number of allowed routes attached to each
+// listener of the given Gateway. Routes without a sectionName count toward
+// listeners that allow their kind.
+func countAttachedRoutes(routes []routeObject, gw *gatewayv1.Gateway) map[gatewayv1.SectionName]int32 {
 	counts := make(map[gatewayv1.SectionName]int32)
-	for _, hr := range routes {
-		for _, ref := range hr.Spec.ParentRefs {
-			if !parentRefMatches(ref, gw, hr.Namespace) {
+	for _, route := range routes {
+		for _, ref := range route.parentRefs() {
+			if !parentRefMatches(ref, gw, route.obj().GetNamespace()) {
 				continue
 			}
 			if ref.SectionName != nil {
-				// Only count if the sectionName matches an actual listener.
 				for _, l := range gw.Spec.Listeners {
-					if l.Name == *ref.SectionName {
+					if l.Name == *ref.SectionName && listenerAllowsKind(l, route.routeKind()) {
 						counts[*ref.SectionName]++
 						break
 					}
 				}
 			} else {
-				// Attach to all listeners.
 				for _, l := range gw.Spec.Listeners {
-					counts[l.Name]++
+					if listenerAllowsKind(l, route.routeKind()) {
+						counts[l.Name]++
+					}
 				}
 			}
 		}
@@ -507,38 +516,54 @@ func findRouteParentStatus(statuses []gatewayv1.RouteParentStatus, gw *gatewayv1
 }
 
 // removeRouteStatuses removes this Gateway's entry from status.parents on all
-// HTTPRoutes that reference it. This is called during Gateway finalization.
+// routes (HTTPRoute and GRPCRoute) that reference it. Called during finalization.
 func (r *GatewayReconciler) removeRouteStatuses(ctx context.Context, gw *gatewayv1.Gateway) error {
-	var routes gatewayv1.HTTPRouteList
-	if err := r.List(ctx, &routes, client.MatchingFields{
-		indexHTTPRouteParentGateway: gw.Namespace + "/" + gw.Name,
+	gwKey := gw.Namespace + "/" + gw.Name
+
+	var httpRoutes gatewayv1.HTTPRouteList
+	if err := r.List(ctx, &httpRoutes, client.MatchingFields{
+		indexHTTPRouteParentGateway: gwKey,
 	}); err != nil {
-		return fmt.Errorf("listing HTTPRoutes for gateway %s/%s: %w", gw.Namespace, gw.Name, err)
+		return fmt.Errorf("listing HTTPRoutes for gateway %s: %w", gwKey, err)
 	}
-	for i := range routes.Items {
-		if err := r.removeRouteStatus(ctx, gw, &routes.Items[i]); err != nil {
+	for i := range httpRoutes.Items {
+		if err := r.removeRouteStatus(ctx, gw, &httpRouteObject{route: &httpRoutes.Items[i]}); err != nil {
 			return err
 		}
 	}
+
+	var grpcRoutes gatewayv1.GRPCRouteList
+	if err := r.List(ctx, &grpcRoutes, client.MatchingFields{
+		indexGRPCRouteParentGateway: gwKey,
+	}); err != nil {
+		return fmt.Errorf("listing GRPCRoutes for gateway %s: %w", gwKey, err)
+	}
+	for i := range grpcRoutes.Items {
+		if err := r.removeRouteStatus(ctx, gw, &grpcRouteObject{route: &grpcRoutes.Items[i]}); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
 // removeRouteStatus removes this Gateway's entry from status.parents on a
-// single HTTPRoute. This is used for stale routes (parentRef removed) and
+// single route. This is used for stale routes (parentRef removed) and
 // during Gateway finalization.
-func (r *GatewayReconciler) removeRouteStatus(ctx context.Context, gw *gatewayv1.Gateway, route *gatewayv1.HTTPRoute) error {
-	routeKey := client.ObjectKeyFromObject(route)
+func (r *GatewayReconciler) removeRouteStatus(ctx context.Context, gw *gatewayv1.Gateway, route routeObject) error {
+	routeKey := route.key()
 	patched := false
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		if err := r.Get(ctx, routeKey, route); err != nil {
+		if err := r.Get(ctx, routeKey, route.obj()); err != nil {
 			return client.IgnoreNotFound(err)
 		}
-		if findRouteParentStatus(route.Status.Parents, gw) == nil {
+		if findRouteParentStatus(*route.routeParents(), gw) == nil {
 			return nil
 		}
-		patch := client.MergeFromWithOptions(route.DeepCopy(), client.MergeFromWithOptimisticLock{})
-		filtered := make([]gatewayv1.RouteParentStatus, 0, len(route.Status.Parents))
-		for _, s := range route.Status.Parents {
+		patch := client.MergeFromWithOptions(route.deepCopy(), client.MergeFromWithOptimisticLock{})
+		parents := route.routeParents()
+		filtered := make([]gatewayv1.RouteParentStatus, 0, len(*parents))
+		for _, s := range *parents {
 			if s.ControllerName == apiv1.ControllerName &&
 				string(s.ParentRef.Name) == gw.Name &&
 				s.ParentRef.Namespace != nil && string(*s.ParentRef.Namespace) == gw.Namespace {
@@ -546,53 +571,54 @@ func (r *GatewayReconciler) removeRouteStatus(ctx context.Context, gw *gatewayv1
 			}
 			filtered = append(filtered, s)
 		}
-		route.Status.Parents = filtered
+		*parents = filtered
 		patched = true
-		if err := r.Status().Patch(ctx, route, patch); err != nil {
-			return fmt.Errorf("removing status entry from HTTPRoute %s/%s: %w", route.Namespace, route.Name, err)
+		if err := r.Status().Patch(ctx, route.obj(), patch); err != nil {
+			return fmt.Errorf("removing status entry from %s %s: %w", route.routeKind(), routeKey, err)
 		}
 		return nil
 	})
 	if patched {
-		log.FromContext(ctx).V(1).Info("Removed status entry from HTTPRoute", "httproute", routeKey)
-		r.Eventf(route, gw, corev1.EventTypeNormal, apiv1.ReasonReconciliationSucceeded,
+		log.FromContext(ctx).V(1).Info("Removed status entry from route", "kind", route.routeKind(), "route", routeKey)
+		r.Eventf(route.obj(), gw, corev1.EventTypeNormal, apiv1.ReasonReconciliationSucceeded,
 			apiv1.EventActionReconcile, "Removed status entry for Gateway %s/%s", gw.Namespace, gw.Name)
 	}
 	return err
 }
 
 // updateDeniedRouteStatus sets Accepted=False/NotAllowedByListeners on the
-// status.parents entry for this Gateway on a denied HTTPRoute (cross-namespace
+// status.parents entry for this Gateway on a denied route (cross-namespace
 // route not permitted by the Gateway's listener allowedRoutes configuration).
 // Any stale conditions from a previous reconciliation (e.g. DNS) are removed.
-func (r *GatewayReconciler) updateDeniedRouteStatus(ctx context.Context, gw *gatewayv1.Gateway, route *gatewayv1.HTTPRoute) error {
+func (r *GatewayReconciler) updateDeniedRouteStatus(ctx context.Context, gw *gatewayv1.Gateway, route routeObject) error {
 	acceptedType := string(gatewayv1.RouteConditionAccepted)
 	acceptedStatus := metav1.ConditionFalse
 	acceptedReason := string(gatewayv1.RouteReasonNotAllowedByListeners)
-	acceptedMsg := fmt.Sprintf("Route namespace %q not allowed by any listener on Gateway %s/%s", route.Namespace, gw.Namespace, gw.Name)
+	acceptedMsg := fmt.Sprintf("Route namespace %q not allowed by any listener on Gateway %s/%s", route.obj().GetNamespace(), gw.Namespace, gw.Name)
 
-	routeKey := client.ObjectKeyFromObject(route)
+	routeKey := route.key()
 	patched := false
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		if err := r.Get(ctx, routeKey, route); err != nil {
+		if err := r.Get(ctx, routeKey, route.obj()); err != nil {
 			return client.IgnoreNotFound(err)
 		}
 
-		existing := findRouteParentStatus(route.Status.Parents, gw)
+		existing := findRouteParentStatus(*route.routeParents(), gw)
 
 		// Skip if the entry already has exactly the right condition.
 		if existing != nil &&
 			len(existing.Conditions) == 1 &&
 			!conditions.Changed(existing.Conditions, acceptedType, acceptedStatus,
-				acceptedReason, acceptedMsg, route.Generation) {
+				acceptedReason, acceptedMsg, route.generation()) {
 			return nil
 		}
 
-		patch := client.MergeFromWithOptions(route.DeepCopy(), client.MergeFromWithOptimisticLock{})
+		patch := client.MergeFromWithOptions(route.deepCopy(), client.MergeFromWithOptimisticLock{})
 		now := metav1.Now()
 
+		parents := route.routeParents()
 		if existing == nil {
-			route.Status.Parents = append(route.Status.Parents, gatewayv1.RouteParentStatus{
+			*parents = append(*parents, gatewayv1.RouteParentStatus{
 				ParentRef: gatewayv1.ParentReference{
 					Group:     new(gatewayv1.Group(gatewayv1.GroupName)),
 					Kind:      new(gatewayv1.Kind(apiv1.KindGateway)),
@@ -601,7 +627,7 @@ func (r *GatewayReconciler) updateDeniedRouteStatus(ctx context.Context, gw *gat
 				},
 				ControllerName: apiv1.ControllerName,
 			})
-			existing = &route.Status.Parents[len(route.Status.Parents)-1]
+			existing = &(*parents)[len(*parents)-1]
 		}
 
 		// Replace all conditions with just Accepted=False/NotAllowedByListeners,
@@ -611,7 +637,7 @@ func (r *GatewayReconciler) updateDeniedRouteStatus(ctx context.Context, gw *gat
 			{
 				Type:               acceptedType,
 				Status:             acceptedStatus,
-				ObservedGeneration: route.Generation,
+				ObservedGeneration: route.generation(),
 				LastTransitionTime: now,
 				Reason:             acceptedReason,
 				Message:            acceptedMsg,
@@ -619,11 +645,11 @@ func (r *GatewayReconciler) updateDeniedRouteStatus(ctx context.Context, gw *gat
 		})
 
 		patched = true
-		return r.Status().Patch(ctx, route, patch)
+		return r.Status().Patch(ctx, route.obj(), patch)
 	})
 	if patched {
-		log.FromContext(ctx).V(1).Info("Patched denied HTTPRoute status", "httproute", routeKey)
-		r.Eventf(route, gw, corev1.EventTypeWarning, acceptedReason,
+		log.FromContext(ctx).V(1).Info("Patched denied route status", "kind", route.routeKind(), "route", routeKey)
+		r.Eventf(route.obj(), gw, corev1.EventTypeWarning, acceptedReason,
 			apiv1.EventActionReconcile, acceptedMsg)
 	}
 	return err
@@ -694,7 +720,7 @@ func validateHTTPRoute(route *gatewayv1.HTTPRoute) []string {
 
 // filterConflictingRoutes reads the existing route ConfigMap, detects conflicts,
 // rejects conflicting routes, and returns the filtered list of non-conflicting routes.
-func (r *GatewayReconciler) filterConflictingRoutes(ctx context.Context, gw *gatewayv1.Gateway, validRoutes []*gatewayv1.HTTPRoute) ([]*gatewayv1.HTTPRoute, []string, error) {
+func (r *GatewayReconciler) filterConflictingRoutes(ctx context.Context, gw *gatewayv1.Gateway, validRoutes []routeObject) ([]routeObject, []string, error) {
 	existingRouteConfig, err := r.getExistingRouteConfig(ctx, gw)
 	if err != nil {
 		return nil, nil, err
@@ -703,15 +729,14 @@ func (r *GatewayReconciler) filterConflictingRoutes(ctx context.Context, gw *gat
 	if len(conflicting) == 0 {
 		return validRoutes, nil, nil
 	}
-	var filtered []*gatewayv1.HTTPRoute
+	var filtered []routeObject
 	var errs []string
 	for _, route := range validRoutes {
-		key := types.NamespacedName{Namespace: route.Namespace, Name: route.Name}
-		if issues, ok := conflicting[key]; ok {
-			msg := "Conflicting hostname/path (already claimed by an earlier HTTPRoute):\n- " + strings.Join(issues, "\n- ")
+		if issues, ok := conflicting[route.key()]; ok {
+			msg := "Conflicting hostname/path (already claimed by an earlier route):\n- " + strings.Join(issues, "\n- ")
 			if err := r.rejectRouteStatus(ctx, gw, route,
 				string(gatewayv1.RouteReasonUnsupportedValue), msg); err != nil {
-				errs = append(errs, fmt.Sprintf("failed to update conflicting HTTPRoute %s/%s status: %v", route.Namespace, route.Name, err))
+				errs = append(errs, fmt.Sprintf("failed to update conflicting %s %s status: %v", route.routeKind(), route.key(), err))
 			}
 			continue
 		}
@@ -720,13 +745,16 @@ func (r *GatewayReconciler) filterConflictingRoutes(ctx context.Context, gw *gat
 	return filtered, errs, nil
 }
 
-// hostnamePathKey is a (hostname, pathPrefix) pair used to detect conflicting routes.
+// hostnamePathKey is a (hostname, pathPrefix, protocol) tuple used to detect
+// conflicting routes. HTTP and gRPC routes on the same hostname don't conflict
+// because the proxy routes them separately based on Content-Type.
 type hostnamePathKey struct {
 	hostname string
 	path     string
+	protocol string
 }
 
-// findConflictingRoutes detects HTTPRoutes that claim the same (hostname, pathPrefix)
+// findConflictingRoutes detects routes that claim the same (hostname, pathPrefix)
 // pair. When two routes produce identical routing keys, only one can actually receive
 // traffic — the other is silently ignored. This returns a map of conflicting routes
 // (route key -> list of conflicting hostname+path descriptions) so the caller can
@@ -736,7 +764,7 @@ type hostnamePathKey struct {
 // Owner field pre-claim their (hostname, pathPrefix) keys, protecting existing traffic
 // from rogue/malicious tenants. Among routes with the same priority, the first one
 // encountered in the input order claims the key.
-func findConflictingRoutes(existingConfig *proxy.Config, routes []*gatewayv1.HTTPRoute) map[types.NamespacedName][]string {
+func findConflictingRoutes(existingConfig *proxy.Config, routes []routeObject) map[types.NamespacedName][]string {
 	type owner struct {
 		namespace string
 		name      string
@@ -753,7 +781,7 @@ func findConflictingRoutes(existingConfig *proxy.Config, routes []*gatewayv1.HTT
 			if len(parts) != 2 {
 				continue
 			}
-			key := hostnamePathKey{hostname: r.Hostname, path: r.PathPrefix}
+			key := hostnamePathKey{hostname: r.Hostname, path: r.PathPrefix, protocol: r.Protocol}
 			claimed[key] = owner{namespace: parts[0], name: parts[1]}
 		}
 	}
@@ -762,23 +790,19 @@ func findConflictingRoutes(existingConfig *proxy.Config, routes []*gatewayv1.HTT
 	// different route, flag as conflict; otherwise claim it.
 	conflicts := make(map[types.NamespacedName][]string)
 	for _, route := range routes {
-		routeKey := types.NamespacedName{Namespace: route.Namespace, Name: route.Name}
-		for _, rule := range route.Spec.Rules {
-			path := pathFromMatches(rule.Matches)
-			for _, hostname := range route.Spec.Hostnames {
-				key := hostnamePathKey{hostname: string(hostname), path: path}
-				if first, ok := claimed[key]; ok {
-					if first.namespace != route.Namespace || first.name != route.Name {
-						desc := string(hostname)
-						if path != "" {
-							desc += path
-						}
-						conflicts[routeKey] = append(conflicts[routeKey],
-							fmt.Sprintf("%s (claimed by %s/%s)", desc, first.namespace, first.name))
+		routeKey := route.key()
+		for _, hpk := range route.hostnamePathKeys() {
+			if first, ok := claimed[hpk]; ok {
+				if first.namespace != routeKey.Namespace || first.name != routeKey.Name {
+					desc := hpk.hostname
+					if hpk.path != "" {
+						desc += hpk.path
 					}
-				} else {
-					claimed[key] = owner{namespace: route.Namespace, name: route.Name}
+					conflicts[routeKey] = append(conflicts[routeKey],
+						fmt.Sprintf("%s (claimed by %s/%s)", desc, first.namespace, first.name))
 				}
+			} else {
+				claimed[hpk] = owner{namespace: routeKey.Namespace, name: routeKey.Name}
 			}
 		}
 	}
@@ -786,35 +810,36 @@ func findConflictingRoutes(existingConfig *proxy.Config, routes []*gatewayv1.HTT
 }
 
 // rejectRouteStatus sets Accepted=False on the status.parents entry for this
-// Gateway on an HTTPRoute. Any stale conditions from a previous
-// reconciliation are removed.
-func (r *GatewayReconciler) rejectRouteStatus(ctx context.Context, gw *gatewayv1.Gateway, route *gatewayv1.HTTPRoute, reason, msg string) error {
+// Gateway on a route. Any stale conditions from a previous reconciliation
+// are removed.
+func (r *GatewayReconciler) rejectRouteStatus(ctx context.Context, gw *gatewayv1.Gateway, route routeObject, reason, msg string) error {
 	acceptedType := string(gatewayv1.RouteConditionAccepted)
 	acceptedStatus := metav1.ConditionFalse
 	acceptedReason := reason
 	acceptedMsg := msg
 
-	routeKey := client.ObjectKeyFromObject(route)
+	routeKey := route.key()
 	patched := false
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		if err := r.Get(ctx, routeKey, route); err != nil {
+		if err := r.Get(ctx, routeKey, route.obj()); err != nil {
 			return client.IgnoreNotFound(err)
 		}
 
-		existing := findRouteParentStatus(route.Status.Parents, gw)
+		existing := findRouteParentStatus(*route.routeParents(), gw)
 
 		if existing != nil &&
 			len(existing.Conditions) == 1 &&
 			!conditions.Changed(existing.Conditions, acceptedType, acceptedStatus,
-				acceptedReason, acceptedMsg, route.Generation) {
+				acceptedReason, acceptedMsg, route.generation()) {
 			return nil
 		}
 
-		patch := client.MergeFromWithOptions(route.DeepCopy(), client.MergeFromWithOptimisticLock{})
+		patch := client.MergeFromWithOptions(route.deepCopy(), client.MergeFromWithOptimisticLock{})
 		now := metav1.Now()
 
+		parents := route.routeParents()
 		if existing == nil {
-			route.Status.Parents = append(route.Status.Parents, gatewayv1.RouteParentStatus{
+			*parents = append(*parents, gatewayv1.RouteParentStatus{
 				ParentRef: gatewayv1.ParentReference{
 					Group:     new(gatewayv1.Group(gatewayv1.GroupName)),
 					Kind:      new(gatewayv1.Kind(apiv1.KindGateway)),
@@ -823,14 +848,14 @@ func (r *GatewayReconciler) rejectRouteStatus(ctx context.Context, gw *gatewayv1
 				},
 				ControllerName: apiv1.ControllerName,
 			})
-			existing = &route.Status.Parents[len(route.Status.Parents)-1]
+			existing = &(*parents)[len(*parents)-1]
 		}
 
 		existing.Conditions = conditions.Set(existing.Conditions, []metav1.Condition{
 			{
 				Type:               acceptedType,
 				Status:             acceptedStatus,
-				ObservedGeneration: route.Generation,
+				ObservedGeneration: route.generation(),
 				LastTransitionTime: now,
 				Reason:             acceptedReason,
 				Message:            acceptedMsg,
@@ -838,75 +863,77 @@ func (r *GatewayReconciler) rejectRouteStatus(ctx context.Context, gw *gatewayv1
 		})
 
 		patched = true
-		return r.Status().Patch(ctx, route, patch)
+		return r.Status().Patch(ctx, route.obj(), patch)
 	})
 	if patched {
-		log.FromContext(ctx).V(1).Info("Patched invalid HTTPRoute status", "httproute", routeKey)
-		r.Eventf(route, gw, corev1.EventTypeWarning, acceptedReason,
+		log.FromContext(ctx).V(1).Info("Patched invalid route status", "kind", route.routeKind(), "route", routeKey)
+		r.Eventf(route.obj(), gw, corev1.EventTypeWarning, acceptedReason,
 			apiv1.EventActionReconcile, acceptedMsg)
 	}
 	return err
 }
 
-// updateRouteStatuses iterates over allowed HTTPRoutes and delegates to
+// updateRouteStatuses iterates over allowed routes and delegates to
 // updateRouteStatus for each one, collecting non-fatal errors.
-func (r *GatewayReconciler) updateRouteStatuses(ctx context.Context, gw *gatewayv1.Gateway, routes []*gatewayv1.HTTPRoute, routesWithDeniedRefs map[types.NamespacedName][]string, dns dnsPolicy, dnsErr *string, readyStatus metav1.ConditionStatus, readyReason, readyMsg string) []string {
+func (r *GatewayReconciler) updateRouteStatuses(ctx context.Context, gw *gatewayv1.Gateway, routes []routeObject, routesWithDeniedRefs map[types.NamespacedName][]string, dns dnsPolicy, dnsErr *string, readyStatus metav1.ConditionStatus, readyReason, readyMsg string) []string {
 	var errs []string
 	for _, route := range routes {
-		deniedRefs := routesWithDeniedRefs[types.NamespacedName{Namespace: route.Namespace, Name: route.Name}]
+		deniedRefs := routesWithDeniedRefs[route.key()]
 		if err := r.updateRouteStatus(ctx, gw, route, deniedRefs, dns, dnsErr, readyStatus, readyReason, readyMsg); err != nil {
-			errs = append(errs, fmt.Sprintf("failed to update HTTPRoute %s/%s status: %v", route.Namespace, route.Name, err))
+			errs = append(errs, fmt.Sprintf("failed to update %s %s status: %v", route.routeKind(), route.key(), err))
 		}
 	}
 	return errs
 }
 
 // updateRouteStatus updates the status.parents entry for this Gateway on the
-// given HTTPRoute using merge-patch. Condition values are pre-computed by
+// given route using merge-patch. Condition values are pre-computed by
 // buildRouteConditions; this method handles the RetryOnConflict + patch logic.
 // If the entry already exists with up-to-date conditions, no patch is issued.
-func (r *GatewayReconciler) updateRouteStatus(ctx context.Context, gw *gatewayv1.Gateway, route *gatewayv1.HTTPRoute, deniedRefs []string, dns dnsPolicy, dnsErr *string, readyStatus metav1.ConditionStatus, readyReason, readyMsg string) error {
+func (r *GatewayReconciler) updateRouteStatus(ctx context.Context, gw *gatewayv1.Gateway, route routeObject, deniedRefs []string, dns dnsPolicy, dnsErr *string, readyStatus metav1.ConditionStatus, readyReason, readyMsg string) error {
 	acceptedType := string(gatewayv1.RouteConditionAccepted)
 	resolvedRefsType := string(gatewayv1.RouteConditionResolvedRefs)
+	acceptedMsg := route.routeKind() + " is accepted"
 	rc := buildRouteConditions(route, deniedRefs, dns, dnsErr, readyStatus, readyReason, readyMsg)
 
-	routeKey := client.ObjectKeyFromObject(route)
+	routeKey := route.key()
 	patched := false
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		if err := r.Get(ctx, routeKey, route); err != nil {
+		if err := r.Get(ctx, routeKey, route.obj()); err != nil {
 			// NotFound must NOT be ignored: the route was deleted mid-reconciliation
 			// and the controller needs a fresh Reconcile() to clean up DNS records
 			// and tunnel ingress rules associated with this route.
 			return err
 		}
 
-		existing := findRouteParentStatus(route.Status.Parents, gw)
+		existing := findRouteParentStatus(*route.routeParents(), gw)
 
 		// Check if update is needed.
 		if existing != nil {
 			changed := conditions.Changed(existing.Conditions, acceptedType, metav1.ConditionTrue,
-				string(gatewayv1.RouteReasonAccepted), "HTTPRoute is accepted", route.Generation) ||
+				string(gatewayv1.RouteReasonAccepted), acceptedMsg, route.generation()) ||
 				conditions.Changed(existing.Conditions, resolvedRefsType, rc.resolvedRefsStatus,
-					rc.resolvedRefsReason, rc.resolvedRefsMsg, route.Generation)
+					rc.resolvedRefsReason, rc.resolvedRefsMsg, route.generation())
 			if rc.dnsEnabled {
 				changed = changed || conditions.Changed(existing.Conditions, apiv1.ConditionDNSRecordsApplied,
-					rc.dnsStatus, rc.dnsReason, rc.dnsMessage, route.Generation)
+					rc.dnsStatus, rc.dnsReason, rc.dnsMessage, route.generation())
 			} else {
 				// DNS was disabled — check if we need to remove a stale condition.
 				changed = changed || conditions.Find(existing.Conditions, apiv1.ConditionDNSRecordsApplied) != nil
 			}
 			changed = changed || conditions.Changed(existing.Conditions, apiv1.ConditionReady,
-				rc.readyStatus, rc.readyReason, rc.readyMsg, route.Generation)
+				rc.readyStatus, rc.readyReason, rc.readyMsg, route.generation())
 			if !changed {
 				return nil
 			}
 		}
 
-		patch := client.MergeFromWithOptions(route.DeepCopy(), client.MergeFromWithOptimisticLock{})
+		patch := client.MergeFromWithOptions(route.deepCopy(), client.MergeFromWithOptimisticLock{})
 		now := metav1.Now()
 
+		parents := route.routeParents()
 		if existing == nil {
-			route.Status.Parents = append(route.Status.Parents, gatewayv1.RouteParentStatus{
+			*parents = append(*parents, gatewayv1.RouteParentStatus{
 				ParentRef: gatewayv1.ParentReference{
 					Group:     new(gatewayv1.Group(gatewayv1.GroupName)),
 					Kind:      new(gatewayv1.Kind(apiv1.KindGateway)),
@@ -915,24 +942,24 @@ func (r *GatewayReconciler) updateRouteStatus(ctx context.Context, gw *gatewayv1
 				},
 				ControllerName: apiv1.ControllerName,
 			})
-			existing = &route.Status.Parents[len(route.Status.Parents)-1]
+			existing = &(*parents)[len(*parents)-1]
 		}
 
 		existing.Conditions = conditions.Upsert(existing.Conditions, metav1.Condition{
 			Type: acceptedType, Status: metav1.ConditionTrue,
-			ObservedGeneration: route.Generation, LastTransitionTime: now,
-			Reason: string(gatewayv1.RouteReasonAccepted), Message: "HTTPRoute is accepted",
+			ObservedGeneration: route.generation(), LastTransitionTime: now,
+			Reason: string(gatewayv1.RouteReasonAccepted), Message: acceptedMsg,
 		})
 		existing.Conditions = conditions.Upsert(existing.Conditions, metav1.Condition{
 			Type: resolvedRefsType, Status: rc.resolvedRefsStatus,
-			ObservedGeneration: route.Generation, LastTransitionTime: now,
+			ObservedGeneration: route.generation(), LastTransitionTime: now,
 			Reason: rc.resolvedRefsReason, Message: rc.resolvedRefsMsg,
 		})
 
 		if rc.dnsEnabled {
 			existing.Conditions = conditions.Upsert(existing.Conditions, metav1.Condition{
 				Type: apiv1.ConditionDNSRecordsApplied, Status: rc.dnsStatus,
-				ObservedGeneration: route.Generation, LastTransitionTime: now,
+				ObservedGeneration: route.generation(), LastTransitionTime: now,
 				Reason: rc.dnsReason, Message: rc.dnsMessage,
 			})
 		} else {
@@ -941,30 +968,30 @@ func (r *GatewayReconciler) updateRouteStatus(ctx context.Context, gw *gatewayv1
 
 		existing.Conditions = conditions.Upsert(existing.Conditions, metav1.Condition{
 			Type: apiv1.ConditionReady, Status: rc.readyStatus,
-			ObservedGeneration: route.Generation, LastTransitionTime: now,
+			ObservedGeneration: route.generation(), LastTransitionTime: now,
 			Reason: rc.readyReason, Message: rc.readyMsg,
 		})
 
 		patched = true
-		return r.Status().Patch(ctx, route, patch)
+		return r.Status().Patch(ctx, route.obj(), patch)
 	})
 	if patched {
-		log.FromContext(ctx).V(1).Info("Patched HTTPRoute status", "httproute", routeKey)
+		log.FromContext(ctx).V(1).Info("Patched route status", "kind", route.routeKind(), "route", routeKey)
 		eventType := corev1.EventTypeNormal
 		if rc.readyStatus != metav1.ConditionTrue {
 			eventType = corev1.EventTypeWarning
 		}
-		r.Eventf(route, gw, eventType, rc.readyReason,
+		r.Eventf(route.obj(), gw, eventType, rc.readyReason,
 			apiv1.EventActionReconcile, "Ready=%s: %s", rc.readyStatus, rc.readyMsg)
 	}
 	return err
 }
 
-// buildRouteConditions computes the desired condition values for an HTTPRoute's
+// buildRouteConditions computes the desired condition values for a route's
 // status.parents entry: ResolvedRefs, DNS (if enabled), and Ready. The Ready
 // condition starts from the Gateway's readiness and is downgraded when DNS errors
 // exist.
-func buildRouteConditions(route *gatewayv1.HTTPRoute, deniedRefs []string, dns dnsPolicy, dnsErr *string, readyStatus metav1.ConditionStatus, readyReason, readyMsg string) routeConditions {
+func buildRouteConditions(route routeObject, deniedRefs []string, dns dnsPolicy, dnsErr *string, readyStatus metav1.ConditionStatus, readyReason, readyMsg string) routeConditions {
 	rc := routeConditions{
 		resolvedRefsStatus: metav1.ConditionTrue,
 		resolvedRefsReason: string(gatewayv1.RouteReasonResolvedRefs),
@@ -1010,22 +1037,23 @@ func buildRouteConditions(route *gatewayv1.HTTPRoute, deniedRefs []string, dns d
 // routeDNSMessage builds a per-route DNS condition message listing the
 // hostnames that were applied and those that were skipped (not in any
 // configured zone).
-func routeDNSMessage(route *gatewayv1.HTTPRoute, dns dnsPolicy) string {
+func routeDNSMessage(route routeObject, dns dnsPolicy) string {
+	hostnames := route.hostnames()
 	// When all zones are managed, every hostname is applied.
 	if dns.allZones() {
 		var msg strings.Builder
 		msg.WriteString("Applied hostnames:")
-		for _, h := range route.Spec.Hostnames {
+		for _, h := range hostnames {
 			fmt.Fprintf(&msg, "\n- %s", string(h))
 		}
-		if len(route.Spec.Hostnames) == 0 {
+		if len(hostnames) == 0 {
 			msg.WriteString("\n(none)")
 		}
 		return msg.String()
 	}
 
 	var applied, skipped []string
-	for _, h := range route.Spec.Hostnames {
+	for _, h := range hostnames {
 		hostname := string(h)
 		matched := false
 		for _, zoneName := range dns.zones {

--- a/internal/controller/gateway_routes_configmap.go
+++ b/internal/controller/gateway_routes_configmap.go
@@ -31,7 +31,7 @@ func routeConfigMapLabels(gw *gatewayv1.Gateway) map[string]string {
 
 // reconcileRouteConfigMap builds the route Config from valid routes and
 // creates/updates the ConfigMap. Returns denied refs, change messages, and error.
-func (r *GatewayReconciler) reconcileRouteConfigMap(ctx context.Context, gw *gatewayv1.Gateway, routes []*gatewayv1.HTTPRoute) (map[types.NamespacedName][]string, []string, error) {
+func (r *GatewayReconciler) reconcileRouteConfigMap(ctx context.Context, gw *gatewayv1.Gateway, routes []routeObject) (map[types.NamespacedName][]string, []string, error) {
 	l := log.FromContext(ctx)
 
 	cfg, routesWithDeniedRefs, err := buildRouteConfig(ctx, r.Client, routes)
@@ -74,89 +74,22 @@ func (r *GatewayReconciler) reconcileRouteConfigMap(ctx context.Context, gw *gat
 	return routesWithDeniedRefs, changes, nil
 }
 
-// buildRouteConfig converts valid HTTPRoutes into route config entries.
-// Each rule's backendRefs are emitted as weighted backends on the route.
+// buildRouteConfig converts valid routes into route config entries.
+// Each route's rules are processed via buildProxyRoutes which handles
+// backend resolution and ReferenceGrant checks.
 // Returns the route config, a map of routes with denied backend refs, and
 // any transient error from ReferenceGrant checks.
-func buildRouteConfig(ctx context.Context, r client.Reader, routes []*gatewayv1.HTTPRoute) (proxy.Config, map[types.NamespacedName][]string, error) {
+func buildRouteConfig(ctx context.Context, r client.Reader, routes []routeObject) (proxy.Config, map[types.NamespacedName][]string, error) {
 	var cfgRoutes []proxy.Route
 	routesWithDeniedRefs := make(map[types.NamespacedName][]string)
 	for _, route := range routes {
-		owner := route.Namespace + "/" + route.Name
-		for _, rule := range route.Spec.Rules {
-			if len(rule.BackendRefs) == 0 {
-				continue
-			}
-			var backends []proxy.Backend
-			denied := false
-			for _, ref := range rule.BackendRefs {
-				ns := route.Namespace
-				if ref.Namespace != nil {
-					ns = string(*ref.Namespace)
-				}
-				granted, err := backendReferenceGranted(ctx, r, route.Namespace, ns, string(ref.Name))
-				if err != nil {
-					return proxy.Config{}, nil, fmt.Errorf("checking ReferenceGrant for backendRef %s/%s in HTTPRoute %s/%s: %w", ns, ref.Name, route.Namespace, route.Name, err)
-				}
-				if !granted {
-					key := types.NamespacedName{Namespace: route.Namespace, Name: route.Name}
-					routesWithDeniedRefs[key] = append(routesWithDeniedRefs[key], ns+"/"+string(ref.Name))
-					denied = true
-					continue
-				}
-				port := int32(80)
-				if ref.Port != nil {
-					port = *ref.Port
-				}
-				weight := int32(1)
-				if ref.Weight != nil {
-					weight = *ref.Weight
-				}
-				service := fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", string(ref.Name), ns, port)
-				backends = append(backends, proxy.Backend{Service: service, Weight: weight})
-			}
-			if denied || len(backends) == 0 {
-				continue
-			}
-			var sp *proxy.SessionPersistence
-			if rule.SessionPersistence != nil {
-				spType := "Cookie"
-				if rule.SessionPersistence.Type != nil {
-					spType = string(*rule.SessionPersistence.Type)
-				}
-				sessionName := "cgw-session"
-				if spType == "Header" {
-					sessionName = "X-Cgw-Session"
-				}
-				if rule.SessionPersistence.SessionName != nil {
-					sessionName = *rule.SessionPersistence.SessionName
-				}
-				sp = &proxy.SessionPersistence{
-					Type:        spType,
-					SessionName: sessionName,
-				}
-				if rule.SessionPersistence.AbsoluteTimeout != nil {
-					sp.AbsoluteTimeout = string(*rule.SessionPersistence.AbsoluteTimeout)
-				}
-				if rule.SessionPersistence.IdleTimeout != nil {
-					sp.IdleTimeout = string(*rule.SessionPersistence.IdleTimeout)
-				}
-				if rule.SessionPersistence.CookieConfig != nil && rule.SessionPersistence.CookieConfig.LifetimeType != nil {
-					sp.CookieLifetimeType = string(*rule.SessionPersistence.CookieConfig.LifetimeType)
-				} else {
-					sp.CookieLifetimeType = "Session"
-				}
-			}
-			pathPrefix := pathFromMatches(rule.Matches)
-			for _, hostname := range route.Spec.Hostnames {
-				cfgRoutes = append(cfgRoutes, proxy.Route{
-					Hostname:           string(hostname),
-					PathPrefix:         pathPrefix,
-					Owner:              owner,
-					Backends:           backends,
-					SessionPersistence: sp,
-				})
-			}
+		proxyRoutes, deniedRefs, err := route.buildProxyRoutes(ctx, r)
+		if err != nil {
+			return proxy.Config{}, nil, err
+		}
+		cfgRoutes = append(cfgRoutes, proxyRoutes...)
+		if len(deniedRefs) > 0 {
+			routesWithDeniedRefs[route.key()] = deniedRefs
 		}
 	}
 	return proxy.Config{Routes: cfgRoutes}, routesWithDeniedRefs, nil

--- a/internal/controller/gatewayclass_controller.go
+++ b/internal/controller/gatewayclass_controller.go
@@ -110,6 +110,7 @@ func (r *GatewayClassReconciler) reconcile(ctx context.Context, gc *gatewayv1.Ga
 	desiredFeatures := []gatewayv1.SupportedFeature{
 		{Name: gatewayv1.FeatureName(features.SupportGateway)},
 		{Name: gatewayv1.FeatureName(features.SupportGatewayInfrastructurePropagation)},
+		{Name: gatewayv1.FeatureName(features.SupportGRPCRoute)},
 		{Name: gatewayv1.FeatureName(features.SupportHTTPRoute)},
 		{Name: gatewayv1.FeatureName(features.SupportReferenceGrant)},
 	}

--- a/internal/controller/gatewayclass_controller_test.go
+++ b/internal/controller/gatewayclass_controller_test.go
@@ -456,6 +456,7 @@ func TestGatewayClassReconciler_SupportedFeatures(t *testing.T) {
 		expected := []gatewayv1.SupportedFeature{
 			{Name: gatewayv1.FeatureName(features.SupportGateway)},
 			{Name: gatewayv1.FeatureName(features.SupportGatewayInfrastructurePropagation)},
+			{Name: gatewayv1.FeatureName(features.SupportGRPCRoute)},
 			{Name: gatewayv1.FeatureName(features.SupportHTTPRoute)},
 			{Name: gatewayv1.FeatureName(features.SupportReferenceGrant)},
 		}

--- a/internal/controller/indexes.go
+++ b/internal/controller/indexes.go
@@ -25,6 +25,8 @@ const (
 	indexGatewayClassGatewayFinalizer       = ".gatewayClass.gatewayFinalizer"
 	indexHTTPRouteParentGateway             = ".httpRoute.parentGateway"
 	indexHTTPRouteBackendServiceNS          = ".httpRoute.backendServiceNamespace"
+	indexGRPCRouteParentGateway             = ".grpcRoute.parentGateway"
+	indexGRPCRouteBackendServiceNS          = ".grpcRoute.backendServiceNamespace"
 )
 
 // SetupIndexes registers all shared cache indexes.
@@ -32,6 +34,7 @@ func SetupIndexes(ctx context.Context, mgr ctrl.Manager) {
 	setupGatewayIndexes(ctx, mgr)
 	setupGatewayClassIndexes(ctx, mgr)
 	setupHTTPRouteIndexes(ctx, mgr)
+	setupGRPCRouteIndexes(ctx, mgr)
 }
 
 func setupGatewayIndexes(ctx context.Context, mgr ctrl.Manager) {
@@ -192,5 +195,73 @@ func setupHTTPRouteIndexes(ctx context.Context, mgr ctrl.Manager) {
 			return keys
 		}); err != nil {
 		panic(fmt.Sprintf("failed to setup index %s: %v", indexHTTPRouteBackendServiceNS, err))
+	}
+}
+
+func setupGRPCRouteIndexes(ctx context.Context, mgr ctrl.Manager) {
+	// Index GRPCRoutes by their parent Gateway references (ns/name) and by
+	// existing status.parents entries managed by our controller.
+	if err := mgr.GetCache().IndexField(ctx, &gatewayv1.GRPCRoute{}, indexGRPCRouteParentGateway,
+		func(obj client.Object) []string {
+			route := obj.(*gatewayv1.GRPCRoute)
+			seen := make(map[string]struct{})
+			var keys []string
+			for _, ref := range route.Spec.ParentRefs {
+				if ref.Group != nil && *ref.Group != gatewayv1.Group(gatewayv1.GroupName) {
+					continue
+				}
+				if ref.Kind != nil && *ref.Kind != gatewayv1.Kind(apiv1.KindGateway) {
+					continue
+				}
+				ns := route.Namespace
+				if ref.Namespace != nil {
+					ns = string(*ref.Namespace)
+				}
+				key := ns + "/" + string(ref.Name)
+				if _, ok := seen[key]; !ok {
+					seen[key] = struct{}{}
+					keys = append(keys, key)
+				}
+			}
+			for _, s := range route.Status.Parents {
+				if s.ControllerName != apiv1.ControllerName {
+					continue
+				}
+				if s.ParentRef.Namespace == nil {
+					continue
+				}
+				key := string(*s.ParentRef.Namespace) + "/" + string(s.ParentRef.Name)
+				if _, ok := seen[key]; !ok {
+					seen[key] = struct{}{}
+					keys = append(keys, key)
+				}
+			}
+			return keys
+		}); err != nil {
+		panic(fmt.Sprintf("failed to setup index %s: %v", indexGRPCRouteParentGateway, err))
+	}
+
+	// Index GRPCRoutes by routeNamespace/backendServiceNamespace for
+	// cross-namespace backend Service references.
+	if err := mgr.GetCache().IndexField(ctx, &gatewayv1.GRPCRoute{}, indexGRPCRouteBackendServiceNS,
+		func(obj client.Object) []string {
+			route := obj.(*gatewayv1.GRPCRoute)
+			seen := make(map[string]struct{})
+			var keys []string
+			for _, rule := range route.Spec.Rules {
+				for _, ref := range rule.BackendRefs {
+					if ref.Namespace == nil || string(*ref.Namespace) == route.Namespace {
+						continue
+					}
+					key := route.Namespace + "/" + string(*ref.Namespace)
+					if _, ok := seen[key]; !ok {
+						seen[key] = struct{}{}
+						keys = append(keys, key)
+					}
+				}
+			}
+			return keys
+		}); err != nil {
+		panic(fmt.Sprintf("failed to setup index %s: %v", indexGRPCRouteBackendServiceNS, err))
 	}
 }

--- a/internal/controller/referencegrant.go
+++ b/internal/controller/referencegrant.go
@@ -54,11 +54,11 @@ func secretReferenceGranted(ctx context.Context, r client.Reader, gatewayNamespa
 	return false, nil
 }
 
-// backendReferenceGranted checks whether an HTTPRoute in routeNamespace is allowed
-// to reference a Service in serviceNamespace. Returns true if both namespaces are
-// the same or if a ReferenceGrant in the Service's namespace permits the
-// cross-namespace reference.
-func backendReferenceGranted(ctx context.Context, r client.Reader, routeNamespace, serviceNamespace, serviceName string) (bool, error) {
+// backendReferenceGranted checks whether a route of the given kind in routeNamespace
+// is allowed to reference a Service in serviceNamespace. Returns true if both
+// namespaces are the same or if a ReferenceGrant in the Service's namespace permits
+// the cross-namespace reference.
+func backendReferenceGranted(ctx context.Context, r client.Reader, routeKind, routeNamespace, serviceNamespace, serviceName string) (bool, error) {
 	if routeNamespace == serviceNamespace {
 		return true, nil
 	}
@@ -73,7 +73,7 @@ func backendReferenceGranted(ctx context.Context, r client.Reader, routeNamespac
 		fromMatch := false
 		for _, from := range grant.Spec.From {
 			if from.Group == gatewayv1beta1.Group(gatewayv1.GroupName) &&
-				from.Kind == gatewayv1beta1.Kind(apiv1.KindHTTPRoute) &&
+				from.Kind == gatewayv1beta1.Kind(routeKind) &&
 				string(from.Namespace) == routeNamespace {
 				fromMatch = true
 				break

--- a/internal/controller/route.go
+++ b/internal/controller/route.go
@@ -1,0 +1,311 @@
+// Copyright 2026 Matheus Pimenta.
+// SPDX-License-Identifier: AGPL-3.0
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	apiv1 "github.com/matheuscscp/cloudflare-gateway-controller/api/v1"
+	"github.com/matheuscscp/cloudflare-gateway-controller/internal/proxy"
+)
+
+// routeObject abstracts HTTPRoute and GRPCRoute for shared reconciliation logic.
+// The obj() method returns the underlying scheme-registered object for API calls.
+type routeObject interface {
+	// obj returns the underlying client.Object (HTTPRoute or GRPCRoute) for API calls.
+	obj() client.Object
+	// routeKind returns the kind string (e.g. "HTTPRoute", "GRPCRoute").
+	routeKind() string
+	// key returns the namespaced name of the route.
+	key() types.NamespacedName
+	// generation returns the route's metadata generation.
+	generation() int64
+	// parentRefs returns spec.parentRefs.
+	parentRefs() []gatewayv1.ParentReference
+	// hostnames returns spec.hostnames.
+	hostnames() []gatewayv1.Hostname
+	// routeParents returns a pointer to the route's status.parents slice
+	// for reading and in-place mutation.
+	routeParents() *[]gatewayv1.RouteParentStatus
+	// deepCopy returns a deep copy of the underlying object for merge-patch.
+	deepCopy() client.Object
+	// validate checks for unsupported features, returning issue descriptions.
+	validate() []string
+	// hostnamePathKeys returns (hostname, pathPrefix) keys for conflict detection.
+	hostnamePathKeys() []hostnamePathKey
+	// buildProxyRoutes converts the route's rules into proxy.Route entries,
+	// checking ReferenceGrants for cross-namespace backends.
+	buildProxyRoutes(ctx context.Context, r client.Reader) (routes []proxy.Route, deniedRefs []string, err error)
+}
+
+// httpRouteObject wraps an HTTPRoute to implement routeObject.
+type httpRouteObject struct {
+	route *gatewayv1.HTTPRoute
+}
+
+func (h *httpRouteObject) obj() client.Object                      { return h.route }
+func (h *httpRouteObject) routeKind() string                       { return apiv1.KindHTTPRoute }
+func (h *httpRouteObject) key() types.NamespacedName               { return client.ObjectKeyFromObject(h.route) }
+func (h *httpRouteObject) generation() int64                       { return h.route.Generation }
+func (h *httpRouteObject) parentRefs() []gatewayv1.ParentReference { return h.route.Spec.ParentRefs }
+func (h *httpRouteObject) hostnames() []gatewayv1.Hostname         { return h.route.Spec.Hostnames }
+func (h *httpRouteObject) routeParents() *[]gatewayv1.RouteParentStatus {
+	return &h.route.Status.Parents
+}
+func (h *httpRouteObject) deepCopy() client.Object { return h.route.DeepCopy() }
+func (h *httpRouteObject) validate() []string      { return validateHTTPRoute(h.route) }
+
+func (h *httpRouteObject) hostnamePathKeys() []hostnamePathKey {
+	keys := make([]hostnamePathKey, 0, len(h.route.Spec.Rules)*len(h.route.Spec.Hostnames))
+	for _, rule := range h.route.Spec.Rules {
+		path := pathFromMatches(rule.Matches)
+		for _, hostname := range h.route.Spec.Hostnames {
+			keys = append(keys, hostnamePathKey{hostname: string(hostname), path: path})
+		}
+	}
+	return keys
+}
+
+func (h *httpRouteObject) buildProxyRoutes(ctx context.Context, r client.Reader) ([]proxy.Route, []string, error) {
+	owner := h.route.Namespace + "/" + h.route.Name
+	var routes []proxy.Route
+	var allDeniedRefs []string
+	for _, rule := range h.route.Spec.Rules {
+		if len(rule.BackendRefs) == 0 {
+			continue
+		}
+		var backends []proxy.Backend
+		denied := false
+		for _, ref := range rule.BackendRefs {
+			backend, deniedRef, err := resolveBackend(ctx, r, h.routeKind(), h.route.Namespace, h.route.Name, ref.BackendRef)
+			if err != nil {
+				return nil, nil, err
+			}
+			if deniedRef != "" {
+				allDeniedRefs = append(allDeniedRefs, deniedRef)
+				denied = true
+				continue
+			}
+			backends = append(backends, *backend)
+		}
+		if denied || len(backends) == 0 {
+			continue
+		}
+		sp := buildSessionPersistence(rule.SessionPersistence)
+		pathPrefix := pathFromMatches(rule.Matches)
+		for _, hostname := range h.route.Spec.Hostnames {
+			routes = append(routes, proxy.Route{
+				Hostname:           string(hostname),
+				PathPrefix:         pathPrefix,
+				Owner:              owner,
+				Backends:           backends,
+				SessionPersistence: sp,
+			})
+		}
+	}
+	return routes, allDeniedRefs, nil
+}
+
+// grpcRouteObject wraps a GRPCRoute to implement routeObject.
+type grpcRouteObject struct {
+	route *gatewayv1.GRPCRoute
+}
+
+func (g *grpcRouteObject) obj() client.Object                      { return g.route }
+func (g *grpcRouteObject) routeKind() string                       { return apiv1.KindGRPCRoute }
+func (g *grpcRouteObject) key() types.NamespacedName               { return client.ObjectKeyFromObject(g.route) }
+func (g *grpcRouteObject) generation() int64                       { return g.route.Generation }
+func (g *grpcRouteObject) parentRefs() []gatewayv1.ParentReference { return g.route.Spec.ParentRefs }
+func (g *grpcRouteObject) hostnames() []gatewayv1.Hostname         { return g.route.Spec.Hostnames }
+func (g *grpcRouteObject) routeParents() *[]gatewayv1.RouteParentStatus {
+	return &g.route.Status.Parents
+}
+func (g *grpcRouteObject) deepCopy() client.Object { return g.route.DeepCopy() }
+func (g *grpcRouteObject) validate() []string      { return validateGRPCRoute(g.route) }
+
+func (g *grpcRouteObject) hostnamePathKeys() []hostnamePathKey {
+	keys := make([]hostnamePathKey, 0, len(g.route.Spec.Rules)*len(g.route.Spec.Hostnames))
+	for range g.route.Spec.Rules {
+		for _, hostname := range g.route.Spec.Hostnames {
+			keys = append(keys, hostnamePathKey{hostname: string(hostname), path: "", protocol: proxy.ProtocolGRPC})
+		}
+	}
+	return keys
+}
+
+func (g *grpcRouteObject) buildProxyRoutes(ctx context.Context, r client.Reader) ([]proxy.Route, []string, error) {
+	owner := g.route.Namespace + "/" + g.route.Name
+	var routes []proxy.Route
+	var allDeniedRefs []string
+	for _, rule := range g.route.Spec.Rules {
+		if len(rule.BackendRefs) == 0 {
+			continue
+		}
+		var backends []proxy.Backend
+		denied := false
+		for _, ref := range rule.BackendRefs {
+			backend, deniedRef, err := resolveBackend(ctx, r, g.routeKind(), g.route.Namespace, g.route.Name, ref.BackendRef)
+			if err != nil {
+				return nil, nil, err
+			}
+			if deniedRef != "" {
+				allDeniedRefs = append(allDeniedRefs, deniedRef)
+				denied = true
+				continue
+			}
+			backends = append(backends, *backend)
+		}
+		if denied || len(backends) == 0 {
+			continue
+		}
+		sp := buildSessionPersistence(rule.SessionPersistence)
+		for _, hostname := range g.route.Spec.Hostnames {
+			routes = append(routes, proxy.Route{
+				Hostname:           string(hostname),
+				Protocol:           proxy.ProtocolGRPC,
+				Owner:              owner,
+				Backends:           backends,
+				SessionPersistence: sp,
+			})
+		}
+	}
+	return routes, allDeniedRefs, nil
+}
+
+// validateGRPCRoute checks that the GRPCRoute only uses features supported by
+// Cloudflare tunnels. Returns a list of unsupported feature descriptions,
+// or nil if valid.
+func validateGRPCRoute(route *gatewayv1.GRPCRoute) []string {
+	var issues []string
+	for i, ref := range route.Spec.ParentRefs {
+		if ref.Port != nil {
+			issues = append(issues, fmt.Sprintf("spec.parentRefs[%d].port is not supported", i))
+		}
+	}
+	for i, rule := range route.Spec.Rules {
+		if len(rule.Filters) > 0 {
+			issues = append(issues, fmt.Sprintf("spec.rules[%d].filters is not supported", i))
+		}
+		if sp := rule.SessionPersistence; sp != nil {
+			if sp.IdleTimeout != nil && sp.Type != nil && *sp.Type == gatewayv1.HeaderBasedSessionPersistence {
+				issues = append(issues, fmt.Sprintf(
+					"spec.rules[%d].sessionPersistence.idleTimeout is not supported for header-based sessions", i))
+			}
+		}
+		if len(rule.BackendRefs) == 0 {
+			issues = append(issues, fmt.Sprintf("spec.rules[%d].backendRefs: at least one backend is required", i))
+		}
+		for j, ref := range rule.BackendRefs {
+			if len(ref.Filters) > 0 {
+				issues = append(issues, fmt.Sprintf("spec.rules[%d].backendRefs[%d].filters is not supported", i, j))
+			}
+			group := ""
+			if ref.Group != nil {
+				group = string(*ref.Group)
+			}
+			kind := apiv1.KindService
+			if ref.Kind != nil {
+				kind = string(*ref.Kind)
+			}
+			if group != "" || kind != apiv1.KindService {
+				issues = append(issues, fmt.Sprintf("spec.rules[%d].backendRefs[%d]: only core Service backends are supported, got group=%q kind=%q", i, j, group, kind))
+			}
+		}
+		for j, m := range rule.Matches {
+			if m.Method != nil {
+				issues = append(issues, fmt.Sprintf("spec.rules[%d].matches[%d].method is not supported", i, j))
+			}
+			if len(m.Headers) > 0 {
+				issues = append(issues, fmt.Sprintf("spec.rules[%d].matches[%d].headers is not supported", i, j))
+			}
+		}
+	}
+	return issues
+}
+
+// resolveBackend resolves a single BackendRef into a proxy.Backend, checking
+// ReferenceGrants for cross-namespace references. Returns the backend (nil if
+// denied), the denied ref description (empty if granted), and any error.
+func resolveBackend(ctx context.Context, r client.Reader, routeKind, routeNamespace, routeName string, ref gatewayv1.BackendRef) (*proxy.Backend, string, error) {
+	ns := routeNamespace
+	if ref.Namespace != nil {
+		ns = string(*ref.Namespace)
+	}
+	granted, err := backendReferenceGranted(ctx, r, routeKind, routeNamespace, ns, string(ref.Name))
+	if err != nil {
+		return nil, "", fmt.Errorf("checking ReferenceGrant for backendRef %s/%s in %s %s/%s: %w", ns, ref.Name, routeKind, routeNamespace, routeName, err)
+	}
+	if !granted {
+		return nil, ns + "/" + string(ref.Name), nil
+	}
+	port := int32(80)
+	if ref.Port != nil {
+		port = *ref.Port
+	}
+	weight := int32(1)
+	if ref.Weight != nil {
+		weight = *ref.Weight
+	}
+	service := fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", string(ref.Name), ns, port)
+	return &proxy.Backend{Service: service, Weight: weight}, "", nil
+}
+
+// buildSessionPersistence converts a Gateway API SessionPersistence spec into
+// the proxy config equivalent.
+func buildSessionPersistence(sp *gatewayv1.SessionPersistence) *proxy.SessionPersistence {
+	if sp == nil {
+		return nil
+	}
+	spType := "Cookie"
+	if sp.Type != nil {
+		spType = string(*sp.Type)
+	}
+	sessionName := "cgw-session"
+	if spType == "Header" {
+		sessionName = "X-Cgw-Session"
+	}
+	if sp.SessionName != nil {
+		sessionName = *sp.SessionName
+	}
+	result := &proxy.SessionPersistence{
+		Type:        spType,
+		SessionName: sessionName,
+	}
+	if sp.AbsoluteTimeout != nil {
+		result.AbsoluteTimeout = string(*sp.AbsoluteTimeout)
+	}
+	if sp.IdleTimeout != nil {
+		result.IdleTimeout = string(*sp.IdleTimeout)
+	}
+	if sp.CookieConfig != nil && sp.CookieConfig.LifetimeType != nil {
+		result.CookieLifetimeType = string(*sp.CookieConfig.LifetimeType)
+	} else {
+		result.CookieLifetimeType = "Session"
+	}
+	return result
+}
+
+// listenerAllowsKind reports whether the given listener allows routes of
+// the specified kind. When allowedRoutes.kinds is empty, both HTTPRoute
+// and GRPCRoute are allowed (matching the controller's supported kinds).
+func listenerAllowsKind(l gatewayv1.Listener, kind string) bool {
+	if l.AllowedRoutes == nil || len(l.AllowedRoutes.Kinds) == 0 {
+		return kind == apiv1.KindHTTPRoute || kind == apiv1.KindGRPCRoute
+	}
+	for _, k := range l.AllowedRoutes.Kinds {
+		group := gatewayv1.Group(gatewayv1.GroupName)
+		if k.Group != nil {
+			group = *k.Group
+		}
+		if group == gatewayv1.Group(gatewayv1.GroupName) && string(k.Kind) == kind {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/proxy/config.go
+++ b/internal/proxy/config.go
@@ -94,7 +94,7 @@ type Backend struct {
 type Route struct {
 	Hostname           string              `json:"hostname"`             // e.g. "app.example.com"
 	PathPrefix         string              `json:"pathPrefix,omitempty"` // e.g. "/api" (match only, forwarded as-is)
-	Protocol           string              `json:"protocol,omitempty"`   // "" for HTTP/1.1, "h2c" for HTTP/2 cleartext (gRPC)
+	Protocol           string              `json:"protocol,omitempty"`   // "" for HTTP, "grpc" for gRPC
 	Owner              string              `json:"owner,omitempty"`      // "namespace/name" of the owning HTTPRoute
 	Backends           []Backend           `json:"backends"`
 	SessionPersistence *SessionPersistence `json:"sessionPersistence,omitempty"`

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -107,6 +107,12 @@ func (p *Proxy) isHealthRequest(r *http.Request) bool {
 	return host == p.healthHostname && r.URL.Path == "/"
 }
 
+// isGRPC reports whether the request is a gRPC request by checking if the
+// Content-Type header starts with "application/grpc".
+func isGRPC(r *http.Request) bool {
+	return strings.HasPrefix(r.Header.Get("Content-Type"), "application/grpc")
+}
+
 // resolveBackend matches a request to a route and picks a backend.
 // Returns the route, backend, whether a session was hit, and the
 // session createdAt timestamp (for cookie re-issue).
@@ -116,7 +122,7 @@ func (p *Proxy) resolveBackend(r *http.Request) (*Route, *Backend, bool, int64, 
 		return nil, nil, false, 0, errConfigNotLoaded
 	}
 
-	route := matchRoute(cfg, r.Host, r.URL.Path)
+	route := matchRoute(cfg, r.Host, r.URL.Path, isGRPC(r))
 	if route == nil {
 		return nil, nil, false, 0, errNoRoute
 	}
@@ -146,10 +152,10 @@ var (
 	errNoBackend       = fmt.Errorf("no available backend")
 )
 
-// ServeHTTP implements http.Handler. It matches the request by hostname (exact)
-// then longest PathPrefix, picks a weighted backend, and forwards the request
-// with DisableKeepAlives so each request opens a fresh TCP connection through
-// kube-proxy.
+// ServeHTTP implements http.Handler. It is called by cloudflared's origin proxy
+// for regular HTTP requests (not WebSocket or gRPC). It matches the request by
+// hostname (exact) then longest PathPrefix, picks a weighted backend, and
+// forwards the request via httputil.ReverseProxy.
 func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if p.isHealthRequest(r) {
 		w.WriteHeader(http.StatusOK)
@@ -181,30 +187,9 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Set or re-issue cookie (cookie-based persistence only).
 	// Re-issue on every response when idleTimeout is configured to refresh lastActivity.
-	if sp := route.SessionPersistence; sp != nil && sp.Type == "Cookie" && (!sessionHit || sp.idleTimeout > 0) {
-		backendID := backend.id
-		createdAt := sessionCreatedAt
-		if !sessionHit {
-			createdAt = time.Now().Unix()
-		}
-		cookiePath := route.PathPrefix
-		if cookiePath == "" {
-			cookiePath = "/"
-		}
+	if needsSessionCookie(route, sessionHit) {
 		proxy.ModifyResponse = func(resp *http.Response) error {
-			cookie := &http.Cookie{
-				Name:     sp.SessionName,
-				Value:    sessionCookieValue(backendID, createdAt, sp.idleTimeout > 0),
-				Path:     cookiePath,
-				HttpOnly: true,
-				SameSite: http.SameSiteLaxMode,
-			}
-			if sp.CookieLifetimeType == "Permanent" {
-				cookie.MaxAge = cookieMaxAge(sp, createdAt)
-			}
-			if v := cookie.String(); v != "" {
-				resp.Header.Add("Set-Cookie", v)
-			}
+			setSessionCookie(resp.Header, route, backend, sessionHit, sessionCreatedAt)
 			return nil
 		}
 	}
@@ -212,11 +197,12 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	proxy.ServeHTTP(w, r)
 }
 
-// RoundTrip implements http.RoundTripper. It resolves the backend using the
-// same routing logic as ServeHTTP, rewrites the request URL, and performs a
-// direct HTTP round-trip to the backend. This is used by the tunnel's origin
-// proxy for WebSocket upgrades, where httputil.ReverseProxy's Hijack-based
-// handling doesn't work with QUIC streams.
+// RoundTrip implements http.RoundTripper. It is called by cloudflared's origin
+// proxy for WebSocket upgrades and gRPC requests, which require direct control
+// over the HTTP round-trip (httputil.ReverseProxy's Hijack-based WebSocket
+// handling doesn't work with cloudflared's streams, and gRPC needs HTTP/2
+// framing with body flushing for streaming RPCs). It resolves the backend using
+// the same routing logic as ServeHTTP and rewrites the request URL.
 func (p *Proxy) RoundTrip(r *http.Request) (*http.Response, error) {
 	if p.isHealthRequest(r) {
 		return &http.Response{
@@ -226,19 +212,31 @@ func (p *Proxy) RoundTrip(r *http.Request) (*http.Response, error) {
 		}, nil
 	}
 
-	route, backend, _, _, err := p.resolveBackend(r)
+	route, backend, sessionHit, sessionCreatedAt, err := p.resolveBackend(r)
 	if err != nil {
 		return nil, err
 	}
 
 	r.URL.Scheme = backend.serviceURL.Scheme
 	r.URL.Host = backend.serviceURL.Host
-	return transportForRoute(route).RoundTrip(r)
+	resp, err := transportForRoute(route).RoundTrip(r)
+	if err != nil {
+		return nil, err
+	}
+
+	if needsSessionCookie(route, sessionHit) {
+		setSessionCookie(resp.Header, route, backend, sessionHit, sessionCreatedAt)
+	}
+	return resp, nil
 }
 
+// ProtocolGRPC is the Protocol value for gRPC routes.
+const ProtocolGRPC = "grpc"
+
 // transportForRoute returns the appropriate HTTP transport for the route's protocol.
+// gRPC routes use h2c (HTTP/2 cleartext); everything else uses HTTP/1.1.
 func transportForRoute(route *Route) http.RoundTripper {
-	if route.Protocol == "h2c" {
+	if route.Protocol == ProtocolGRPC {
 		return h2cTransport
 	}
 	return noKeepAliveTransport
@@ -374,6 +372,39 @@ func cookieMaxAge(sp *SessionPersistence, createdAt int64) int {
 	}
 }
 
+// needsSessionCookie reports whether a session cookie should be set or
+// re-issued on the response.
+func needsSessionCookie(route *Route, sessionHit bool) bool {
+	sp := route.SessionPersistence
+	return sp != nil && sp.Type == "Cookie" && (!sessionHit || sp.idleTimeout > 0)
+}
+
+// setSessionCookie adds a Set-Cookie header for session persistence.
+func setSessionCookie(h http.Header, route *Route, backend *Backend, sessionHit bool, sessionCreatedAt int64) {
+	sp := route.SessionPersistence
+	createdAt := sessionCreatedAt
+	if !sessionHit {
+		createdAt = time.Now().Unix()
+	}
+	cookiePath := route.PathPrefix
+	if cookiePath == "" {
+		cookiePath = "/"
+	}
+	cookie := &http.Cookie{
+		Name:     sp.SessionName,
+		Value:    sessionCookieValue(backend.id, createdAt, sp.idleTimeout > 0),
+		Path:     cookiePath,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	}
+	if sp.CookieLifetimeType == "Permanent" {
+		cookie.MaxAge = cookieMaxAge(sp, createdAt)
+	}
+	if v := cookie.String(); v != "" {
+		h.Add("Set-Cookie", v)
+	}
+}
+
 // pickBackend selects a backend from the route using weighted random selection.
 // Backends with weight 0 are never selected. Returns nil if no backend is
 // available (empty slice or all weights are 0).
@@ -394,8 +425,10 @@ func pickBackend(route *Route) *Backend {
 }
 
 // matchRoute finds the best matching route: exact hostname match via the
-// precomputed index, then longest PathPrefix. Returns nil if no route matches.
-func matchRoute(cfg *Config, host, path string) *Route {
+// precomputed index, protocol match, then longest PathPrefix. gRPC requests
+// only match routes with Protocol "grpc"; non-gRPC requests only match routes
+// without a protocol set. Returns nil if no route matches.
+func matchRoute(cfg *Config, host, path string, grpc bool) *Route {
 	// Strip port from host if present.
 	if i := strings.LastIndex(host, ":"); i != -1 {
 		host = host[:i]
@@ -405,6 +438,9 @@ func matchRoute(cfg *Config, host, path string) *Route {
 	var best *Route
 	bestLen := -1
 	for _, r := range routes {
+		if grpc != (r.Protocol == ProtocolGRPC) {
+			continue
+		}
 		prefix := r.PathPrefix
 		if prefix == "" {
 			prefix = "/"

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1548,3 +1548,72 @@ func TestProxy_EmptyHealthURL(t *testing.T) {
 	p.ServeHTTP(rec, req)
 	g.Expect(rec.Code).To(Equal(http.StatusBadGateway))
 }
+
+func TestProxy_GRPCRouteMatching(t *testing.T) {
+	g := NewWithT(t)
+
+	httpBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("http"))
+	}))
+	defer httpBackend.Close()
+
+	p := proxy.NewProxy(nil, "")
+	setConfig(t, p, &proxy.Config{
+		Routes: []proxy.Route{
+			{Hostname: "app.example.com", Backends: []proxy.Backend{{Service: httpBackend.URL, Weight: 1}}},
+			{Hostname: "app.example.com", Protocol: proxy.ProtocolGRPC, Backends: []proxy.Backend{{Service: "http://grpc-backend:9090", Weight: 1}}},
+		},
+	})
+
+	// Regular HTTP request matches the HTTP route (not the gRPC route).
+	req := httptest.NewRequest("GET", "http://app.example.com/", nil)
+	rec := httptest.NewRecorder()
+	p.ServeHTTP(rec, req)
+	g.Expect(rec.Code).To(Equal(http.StatusOK))
+	g.Expect(rec.Body.String()).To(Equal("http"))
+
+	// gRPC request does NOT match the HTTP route via ServeHTTP — returns 404
+	// because the only route for this hostname+protocol(grpc) has an unreachable
+	// backend. In practice, gRPC goes through RoundTrip, not ServeHTTP.
+	// We verify protocol isolation via the NoMatch test below.
+}
+
+func TestProxy_GRPCNoMatchHTTP(t *testing.T) {
+	g := NewWithT(t)
+
+	// Only a gRPC route — regular HTTP requests should get 404.
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("grpc"))
+	}))
+	defer backend.Close()
+
+	p := proxy.NewProxy(nil, "")
+	setConfig(t, p, &proxy.Config{
+		Routes: []proxy.Route{
+			{Hostname: "app.example.com", Protocol: proxy.ProtocolGRPC, Backends: []proxy.Backend{{Service: backend.URL, Weight: 1}}},
+		},
+	})
+
+	req := httptest.NewRequest("GET", "http://app.example.com/", nil)
+	rec := httptest.NewRecorder()
+	p.ServeHTTP(rec, req)
+	g.Expect(rec.Code).To(Equal(http.StatusNotFound))
+}
+
+func TestProxy_GRPCRoundTrip_NoRoute(t *testing.T) {
+	g := NewWithT(t)
+
+	// RoundTrip for a gRPC request that doesn't match any route returns error.
+	p := proxy.NewProxy(nil, "")
+	setConfig(t, p, &proxy.Config{
+		Routes: []proxy.Route{
+			{Hostname: "app.example.com", Backends: []proxy.Backend{{Service: "http://backend:8080", Weight: 1}}},
+		},
+	})
+
+	req := httptest.NewRequest("POST", "http://app.example.com/svc.Method", nil)
+	req.Header.Set("Content-Type", "application/grpc")
+	_, err := p.RoundTrip(req)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("no matching route"))
+}


### PR DESCRIPTION
Closes: #45

In the future, switch to GRPCRoute from the podinfo chart after https://github.com/stefanprodan/podinfo/pull/458 is released.